### PR TITLE
SABR-3: "Determine how unit tests work in saber"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,12 @@
 {
 	"files.associations": {
 		"stdexcept": "cpp"
+	},
+	"cmake.configureSettings": {
+		
+		"CMAKE_BUILD_TYPE": "${buildType}",
+		"SABER_BUILD_TESTS": true,
+		"SABER_BUILD_BENCHMARKS": false,
+		"SABER_BUILD_DOCS": false,
 	}
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,19 +19,11 @@ option(SABER_BUILD_DOCS "Build Doxygen Documentation" OFF)
 # Add saber headers to #include searchpath
 include_directories(include)
 
-if(SABER_BUILD_TESTS)
-	# Must be top-level or test won't be found.
-	include(CTest) # enable_testing() invoked here!
-	add_subdirectory(test)
-endif() # SABER_BUILD_TESTS
-
-# if(SABER_BUILD_DOCS)
-#	add_subdirectory(doc/assets) # Build docset assets
-#	add_subdirectory(doc/doxygen) # Build docset doxygen output
-# endif() # SABER_BUILD_DOCS
-
 # Gather headers into an interface library.
-file(GLOB_RECURSE HEADER_FILES "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.h")
+file(GLOB_RECURSE HEADER_FILES
+	"${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.h"
+	"${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.hpp")
+	
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
@@ -56,3 +48,14 @@ install(EXPORT ${PROJECT_NAME_LOWER}_targets
 
 # Install the headers at a standard cmake location.
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+if(SABER_BUILD_TESTS)
+	# Must be top-level or test won't be found.
+	include(CTest) # enable_testing() invoked here!
+	add_subdirectory(test)
+endif() # SABER_BUILD_TESTS
+
+# if(SABER_BUILD_DOCS)
+#	add_subdirectory(doc/assets) # Build docset assets
+#	add_subdirectory(doc/doxygen) # Build docset doxygen output
+# endif() # SABER_BUILD_DOCS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+
+cmake_minimum_required(VERSION 3.15)
+
+project(
+	saber
+	VERSION		1.0
+	DESCRIPTION	"Saber Utilities C++ Header Library")
+
+# Organizes project into folders to reduce clutter
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+include(GNUInstallDirs)
+
+# From ./.vscode/settings.json: "cmake.configureSettings"
+option(SABER_BUILD_TESTS "Build Unit Tests" OFF)
+option(SABER_BUILD_BENCHMARKS "Build Benchmarks" OFF)
+option(SABER_BUILD_DOCS "Build Doxygen Documentation" OFF)
+
+# Add saber headers to #include searchpath
+include_directories(include)
+
+if(SABER_BUILD_TESTS)
+	# Must be top-level or test won't be found.
+	include(CTest) # enable_testing() invoked here!
+	add_subdirectory(test)
+endif() # SABER_BUILD_TESTS
+
+# if(SABER_BUILD_DOCS)
+#	add_subdirectory(doc/assets) # Build docset assets
+#	add_subdirectory(doc/doxygen) # Build docset doxygen output
+# endif() # SABER_BUILD_DOCS
+
+# Gather headers into an interface library.
+file(GLOB_RECURSE HEADER_FILES "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/*.h")
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# The interface's include directory.
+target_include_directories(${PROJECT_NAME} INTERFACE
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+# Include the .natvis files
+if (MSVC)
+	target_sources(${PROJECT_NAME} INTERFACE
+		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/natvis/${PROJECT_NAME}.natvis>")
+endif() # MSVC
+
+# Install Package Configuration
+string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME_LOWER}_targets)
+install(EXPORT ${PROJECT_NAME_LOWER}_targets
+	NAMESPACE ${PROJECT_NAME}::
+	FILE ${PROJECT_NAME_LOWER}Config.cmake
+	DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}")
+
+# Install the headers at a standard cmake location.
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/cmake/cxxflags_common.cmake
+++ b/cmake/cxxflags_common.cmake
@@ -1,0 +1,80 @@
+
+
+# This is unfortunately still needed to disable exceptions/RTTI since modern CMake still has no builtin support...
+# E.g. replace_cxx_flag("/EHsc", "/EHs-c-")
+macro(replace_cxx_flag pattern text)
+    foreach (flag
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+
+        string(REGEX REPLACE "${pattern}" "${text}" ${flag} "${${flag}}")
+
+    endforeach()
+endmacro()
+
+# Fixup default compiler settings
+if (MSVC)
+    add_compile_options(
+        # Be as strict as reasonably possible, since we want to support consumers using strict warning levels
+        /W4 /WX
+        )
+else()
+    # Clang with non-MSVC commandline syntax
+    add_compile_options(
+        # Effectively the same as /W4 /WX
+        -Wall -Werror
+    )
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(
+        # Ignore some pedantic warnings enabled by '-Wextra'
+        -Wno-missing-field-initializers
+
+        # Ignore some pedantic warnings enabled by '-Wpedantic'
+        -Wno-language-extension-token
+        -Wno-c++17-attribute-extensions
+        -Wno-gnu-zero-variadic-macro-arguments
+        -Wno-extra-semi
+
+        # For tests, we want to be able to test self assignment, so disable this warning
+        -Wno-self-assign-overloaded
+        -Wno-self-move
+
+        # clang needs this to enable _InterlockedCompareExchange128
+        -mcx16
+
+        # We don't want legacy MSVC conformance
+        -fno-delayed-template-parsing
+
+        # NOTE: Windows headers not clean enough for us to realistically attempt to start fixing these errors yet. That
+        # said, errors that originate from WIL headers may benefit
+        # -fno-ms-compatibility
+        # -ferror-limit=999
+        # -fmacro-backtrace-limit=0
+
+        # -fno-ms-compatibility turns off preprocessor compatability, which currently only works when __VA_OPT__ support
+        # is available (i.e. >= C++20)
+        # -Xclang -std=c++2a
+        )
+else()
+    add_compile_options(
+        # We want to be as conformant as possible, so tell MSVC to not be permissive (note that this has no effect on clang-cl)
+        /permissive-
+
+        # wistd::function has padding due to alignment. This is expected
+        /wd4324
+
+        # TODO: https://github.com/Microsoft/wil/issues/6
+        # /experimental:preprocessor
+
+        # CRT headers are not yet /experimental:preprocessor clean, so work around the known issues
+        # /Wv:18
+
+        # Some tests have a LOT of template instantiations
+        /bigobj
+
+        # NOTE: Temporary workaround while https://github.com/microsoft/wil/issues/102 is being investigated
+        /d2FH4-
+        )
+endif()

--- a/include/saber/conditionals.hpp
+++ b/include/saber/conditionals.hpp
@@ -141,6 +141,7 @@
 #undef SABER_PRIVATE_PLATFORM_IOS
 #undef SABER_PRIVATE_PLATFORM_OSX
 #undef SABER_PRIVATE_PLATFORM_LINUX
+// #undef SABER_PRIVATE_PLATFORM_POSIX // not yet
 #undef SABER_PRIVATE_PLATFORM_WIN32
 
 #undef SABER_PRIVATE_COMPILER_CLANG
@@ -149,10 +150,9 @@
 
 #pragma endregion ()
 
-#if defined(_MSC_VER) // MSVC-specific "magic" preprocessor symbol announcing "Microsoft"
-// ---------------------------------------------------
-// Microsoft:
-// #if SABER_PLATFORM(WIN32)...
+#if defined(_MSC_VER) // MSVC-specific preprocessor symbol announcing "Microsoft" toolset
+// ------------------------------------------------------------------
+#pragma region WIN32: Visual Studio toolset detection
 
 	#include <winapifamily.h>
 	#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) // exclude UWP apps
@@ -213,10 +213,11 @@
 //		#define SABER_PRIVATE_PLATFORM_LINUX(platform)	1
 //		// etc...
 
-#elif defined(__APPLE__) && defined(__MACH__) // Xcode-specific "magic" preprocessor symbols announcing "Apple"
-// ---------------------------------------------------
-// Apple:
-// #if SABER_PLATFORM(OSX) || SABER_PLATFORM(IOS)...
+#pragma endregion ()
+
+#elif defined(__APPLE__) && defined(__MACH__) // Xcode-specific preprocessor symbols announcing "Apple"
+// ------------------------------------------------------------------
+#pragma region OSX/IOS: Xcode toolset detection
 
 	#include <TargetConditionals.h>
 	#if TARGET_OS_MAC // OSX
@@ -259,10 +260,11 @@
 	#define SABER_LOG(expr)
 	#define SABER_THROW(expr)
 
-#elif defined(__linux__) // GCC-specific "magic" preprocessor symbol announcing "Linux"
-// ---------------------------------------------------
-// Linux:
-// #if SABER_PLATFORM(LINUX) || SABER_PLATFORM(ANDROID)...
+#pragma endregion ()
+
+#elif defined(__linux__) // Clang/GCC-specific preprocessor symbol announcing "Linux"
+// ------------------------------------------------------------------
+#pragma region Linux: Xcode toolset detection
 
 	#define SABER_PRIVATE_PLATFORM_LINUX(platform)	1
 	// Not yet...
@@ -313,6 +315,8 @@
 	#define SABER_DEBUG	(!defined(NDEBUG))
 	#define SABER_LOG(expr)
 	#define SABER_THROW(expr)
+
+#pragma endregion ()
 
 #else
 #error "Unsupported toolset"

--- a/natvis/saber.natvis
+++ b/natvis/saber.natvis
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) Microsoft. All rights reserved.
+    This code is licensed under the MIT License.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+    PARTICULAR PURPOSE AND NONINFRINGEMENT.
+-->
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="wistd::default_delete&lt;*&gt;">
+        <DisplayString>default_delete</DisplayString>
+        <Expand />
+    </Type>
+
+    <Type Name="wistd::__compressed_pair_elem&lt;*,*,0&gt;">
+        <Intrinsic Name="get" Expression="__value_" />
+        <DisplayString>{get()}</DisplayString>
+        <Expand>
+            <ExpandedItem>get()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::__compressed_pair_elem&lt;*,*,1&gt;">
+        <Intrinsic Name="get" Expression="*($T1*)this" />
+        <DisplayString>{get()}</DisplayString>
+        <Expand>
+            <ExpandedItem>get()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::__compressed_pair&lt;*&gt;">
+        <Intrinsic Name="first" Expression="(static_cast&lt;_Base1*&gt;(this))->get()" />
+        <Intrinsic Name="second" Expression="(static_cast&lt;_Base2*&gt;(this))->get()" />
+        <DisplayString>({first()}, {second()})</DisplayString>
+        <Expand>
+            <Item Name="[first]">first()</Item>
+            <Item Name="[second]">second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::__function::__func&lt;*&gt;">
+        <DisplayString>{__f_}</DisplayString>
+        <Expand>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::function&lt;*&gt;">
+        <DisplayString Condition="__f_ == 0">empty</DisplayString>
+        <DisplayString Condition="__f_ != 0">{*__f_}</DisplayString>
+        <Expand>
+            <ExpandedItem Condition="__f_ != 0">*__f_</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::unique_ptr&lt;*&gt;">
+        <SmartPointer Usage="Minimal">__ptr_.first()</SmartPointer>
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{*__ptr_.first()}</DisplayString>
+        <Expand>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::unique_ptr&lt;wchar_t[],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),su}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
+        <Expand>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">wcslen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::unique_ptr&lt;wchar_t[*],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),su}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
+        <Expand>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">wcslen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::unique_ptr&lt;char[],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),s}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
+        <Expand>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">strlen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wistd::unique_ptr&lt;char[*],*&gt;">
+        <DisplayString Condition="__ptr_.first() == 0">empty</DisplayString>
+        <DisplayString Condition="__ptr_.first() != 0">{__ptr_.first(),s}</DisplayString>
+        <StringView>__ptr_.first()</StringView>
+        <Expand>
+            <Item Name="[ptr]" Condition="__ptr_.first() != 0">__ptr_.first()</Item>
+            <Item Name="[length]" Condition="__ptr_.first() != 0">strlen(__ptr_.first())</Item>
+            <Item Name="[deleter]" Condition="__ptr_.first() != 0">__ptr_.second()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wil::details::shared_storage&lt;*&gt;">
+        <DisplayString Condition="m_ptr == 0">empty</DisplayString>
+        <DisplayString Condition="m_ptr != 0">{*m_ptr}</DisplayString>
+        <StringView>m_ptr</StringView>
+        <Expand>
+            <Item Name="[pointer]" Condition="m_ptr != 0">m_ptr</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wil::details::unique_storage&lt;wil::details::handle_null_resource_policy&lt;*&gt;&gt;">
+        <DisplayString Condition="m_ptr == 0">empty</DisplayString>
+        <DisplayString Condition="m_ptr != 0">{m_ptr}</DisplayString>
+        <Expand>
+        </Expand>
+    </Type>
+    <Type Name="wil::details::unique_storage&lt;wil::details::handle_invalid_resource_policy&lt;*&gt;&gt;">
+        <DisplayString Condition="m_ptr == 0">empty</DisplayString>
+        <DisplayString Condition="m_ptr != 0">{m_ptr}</DisplayString>
+        <Expand>
+        </Expand>
+    </Type>
+    <Type Name="wil::details::unique_storage&lt;wil::details::resource_policy&lt;*&gt;&gt;">
+        <DisplayString Condition="m_ptr == 0">empty</DisplayString>
+        <DisplayString Condition="m_ptr != 0">{m_ptr}</DisplayString>
+        <StringView>m_ptr</StringView>
+        <Expand>
+        </Expand>
+    </Type>
+    <Type Name="wil::details::unique_storage&lt;wil::details::resource_policy&lt;wchar_t *,*&gt;&gt;">
+        <DisplayString Condition="m_ptr == 0">empty</DisplayString>
+        <DisplayString Condition="m_ptr != 0">{m_ptr,su}</DisplayString>
+        <StringView>m_ptr</StringView>
+        <Expand>
+            <Item Name="[length]" Condition="m_ptr != 0">wcslen(m_ptr)</Item>
+        </Expand>
+    </Type>
+    <Type Name="wil::details::unique_storage&lt;wil::details::resource_policy&lt;char *,*&gt;&gt;">
+        <DisplayString Condition="m_ptr == 0">empty</DisplayString>
+        <DisplayString Condition="m_ptr != 0">{m_ptr,s}</DisplayString>
+        <StringView>m_ptr</StringView>
+        <Expand>
+            <Item Name="[length]" Condition="m_ptr != 0">strlen(m_ptr)</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="wil::com_ptr_t&lt;*&gt;">
+        <DisplayString>{m_ptr}</DisplayString>
+        <Expand>
+            <ExpandedItem>m_ptr</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="wil::basic_zstring_view&lt;*&gt;">
+        <Intrinsic Name="size" Expression="_Mysize" />
+        <Intrinsic Name="data" Expression="_Mydata" />
+        <DisplayString>{_Mydata,[_Mysize]}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
+        </Expand>
+    </Type>
+</AutoVisualizer>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,134 @@
+message(STATUS "Building saber/test/...")
+
+include(FetchContent)
+include(${PROJECT_SOURCE_DIR}/cmake/cxxflags_common.cmake)
+
+if(SABER_BUILD_TESTS)
+
+	FetchContent_Declare(
+		Catch2
+		GIT_REPOSITORY	https://github.com/catchorg/Catch2.git
+		GIT_TAG			v3.6.0)
+
+	FetchContent_MakeAvailable(Catch2)
+
+	add_executable(sabre_test saber_test.cpp)
+	# Catch2 provides a main function as executable entry point.
+	# Private since there is no need to surface these libraries in the binary.
+	target_link_libraries(sabre_test PRIVATE Catch2 Catch2WithMain)
+	add_test(NAME sabre_test COMMAND test)
+
+endif() # SABER_BUILD_TESTS
+
+#if(SABER_BUILD_BENCHMARKS)
+#
+#	FetchContent_Declare(
+#		googlebenchmark
+#		GIT_REPOSITORY	https://github.com/google/benchmark.git
+#		GIT_TAG			v1.8.3)
+#
+#	FetchContent_Declare(
+#		googletest
+#		GIT_REPOSITORY	https://github.com/google/googletest.git
+#		GIT_TAG			v1.14.0)  
+#
+#	FetchContent_MakeAvailable(googlebenchmark googletest)
+#
+#	add_executable(sabre_benchmark benchmark.cpp benchmark_common.h)
+#	add_test(NAME sabre_benchmark COMMAND test)
+#	target_link_libraries(sabre_benchmark PUBLIC benchmark::benchmark)
+#
+#	add_executable(saber_baseline benchmark_baseline.cpp benchmark_common.h)
+#	add_test(NAME saber_baseline COMMAND test)
+#	target_link_libraries(saber_baseline PUBLIC benchmark::benchmark)
+#
+#	py3_build(benchmark_report.py)
+#
+#	file(COPY benchmark.sh
+#		DESTINATION ${CMAKE_CURRENT_BINARY_DIR} 
+#		USE_SOURCE_PERMISSIONS)
+#
+#endif() # SABER_BUILD_BENCHMARKS
+
+# The build pipelines have limitations that local development environments do not, so turn a few knobs
+#if (${FAST_BUILD})
+#	if (MSVC)
+#		replace_cxx_flag("/GR" "/GR-") # Disables RTTI
+#	else()
+#		add_compile_options(-fno-rtti)
+#	endif()
+#
+#	add_definitions(-DCATCH_CONFIG_FAST_COMPILE -DWIL_FAST_BUILD)
+#endif() # FAST_BUILD
+
+# All projects need to reference the Saber headers
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+# Create a customized structure to hold header files when viewed through the IDE
+# Header files will appear in an IDE folder called "Header Files"
+source_group(
+	TREE "include/${PROJECT_SOURCE_DIR}"
+	PREFIX "Header Files"
+	FILES ${HEADER_LIST})
+
+include_directories(BEFORE SYSTEM ${CMAKE_BINARY_DIR}/include)
+
+set(COMMON_SOURCES
+	${CMAKE_CURRENT_SOURCE_DIR}/saber_test.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/../natvis/saber.natvis)
+
+# find_package(Catch2 CONFIG REQUIRED)
+link_libraries(Catch2::Catch2WithMain)
+
+set(CMAKE_CXX_STANDARD 17)
+
+if (MSVC)
+	add_definitions(-DNOMINMAX=1 -DWIN32_LEAN_AND_MEAN=1)
+	add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/saber.natvis)
+
+	# For some unknown reason, 'RelWithDebInfo' compiles with '/Ob1' as opposed to '/Ob2' which prevents inlining of
+	# functions not marked 'inline'. The reason we prefer 'RelWithDebInfo' over 'Release' is to get debug info, so manually
+	# revert to the desired (and default) inlining behavior as that exercises more interesting code paths
+	if ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+		# TODO: This is currently blocked by an apparent Clang bug: https://github.com/llvm/llvm-project/issues/59690
+		# replace_cxx_flag("/Ob1" "/Ob2")
+		replace_cxx_flag("/Ob1" "/Ob2")
+	endif() # STREQUAL "RelWithDebInfo"
+endif() # MSVC
+
+#add_subdirectory(win32)
+#add_subdirectory(osx)
+#add_subdirectory(posix)
+
+#set(DEBUG_BUILD FALSE)
+#set(HAS_DEBUG_INFO FALSE)
+#
+#if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+#	set(DEBUG_BUILD TRUE)
+#	set(HAS_DEBUG_INFO TRUE)
+#elseif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+#	set(HAS_DEBUG_INFO TRUE)
+#endif()
+# Release & MinSizeRel => keep all false
+
+#set(ASAN_AVAILABLE FALSE)
+#set(UBSAN_AVAILABLE FALSE)
+#if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+#	# Address Sanitizer is available for all architectures and build types, but warns/errors if debug info is not enabled
+#	set(ASAN_AVAILABLE ${HAS_DEBUG_INFO})
+#elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+#	# Sanitizers are not available with debug libraries
+#	# Starting with Clang 17, there appears to be some issue where linking to the dynamic asan libraries seems to think that
+#	# things like 'operator new' are present in the executable, but only for x64 for some reason
+#	set(ASAN_AVAILABLE NOT ${DEBUG_BUILD} AND $ENV{Platform} STREQUAL "x86")
+#	set(UBSAN_AVAILABLE NOT ${DEBUG_BUILD})
+#endif()
+#
+#if (${ASAN_AVAILABLE})
+#	add_subdirectory(sanitize-address)
+#endif()
+#
+#if (${UBSAN_AVAILABLE})
+#	# TODO: Disabled until https://github.com/microsoft/STL/issues/3568 is resolved
+#	# add_subdirectory(sanitize-undefined-behavior)
+#endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,22 @@ message(STATUS "Building saber/test/...")
 include(FetchContent)
 include(${PROJECT_SOURCE_DIR}/cmake/cxxflags_common.cmake)
 
+set(CMAKE_CXX_STANDARD 17)
+
+if (MSVC)
+	add_definitions(-DNOMINMAX=1 -DWIN32_LEAN_AND_MEAN=1)
+	add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/saber.natvis)
+
+	# For some unknown reason, 'RelWithDebInfo' compiles with '/Ob1' as opposed to '/Ob2' which prevents inlining of
+	# functions not marked 'inline'. The reason we prefer 'RelWithDebInfo' over 'Release' is to get debug info, so manually
+	# revert to the desired (and default) inlining behavior as that exercises more interesting code paths
+	if ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+		# TODO: This is currently blocked by an apparent Clang bug: https://github.com/llvm/llvm-project/issues/59690
+		# replace_cxx_flag("/Ob1" "/Ob2")
+		replace_cxx_flag("/Ob1" "/Ob2")
+	endif() # STREQUAL "RelWithDebInfo"
+endif() # MSVC
+
 if(SABER_BUILD_TESTS)
 
 	FetchContent_Declare(
@@ -12,11 +28,37 @@ if(SABER_BUILD_TESTS)
 
 	FetchContent_MakeAvailable(Catch2)
 
-	add_executable(sabre_test saber_test.cpp)
+	set(SOURCE_FILES
+		${CMAKE_CURRENT_SOURCE_DIR}/saber_test.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
+
+	add_executable(saber_test ${SOURCE_FILES})
+
+	# Saber unittest source files will appear in an IDE folder called "test"
+	source_group(
+		TREE "${PROJECT_SOURCE_DIR}/test"
+		PREFIX "test"
+		FILES ${SOURCE_FILES})	
+
+	# All projects need to reference the Saber headers
+	include_directories(${PROJECT_SOURCE_DIR}/include)
+
+	# Create a customized structure to hold header files when viewed through the IDE
+	# Saber header files will appear in an IDE folder called "include/saber"
+	source_group(
+		TREE "${PROJECT_SOURCE_DIR}/include"
+		PREFIX "include"
+		FILES ${HEADER_FILES})
+
+	include_directories(BEFORE SYSTEM ${CMAKE_BINARY_DIR}/include)
+
+	# find_package(Catch2 CONFIG REQUIRED)
+	link_libraries(Catch2::Catch2WithMain)
+
 	# Catch2 provides a main function as executable entry point.
 	# Private since there is no need to surface these libraries in the binary.
-	target_link_libraries(sabre_test PRIVATE Catch2 Catch2WithMain)
-	add_test(NAME sabre_test COMMAND test)
+	target_link_libraries(saber_test PRIVATE Catch2 Catch2WithMain)
+	add_test(NAME saber_test COMMAND test)
 
 endif() # SABER_BUILD_TESTS
 
@@ -34,9 +76,9 @@ endif() # SABER_BUILD_TESTS
 #
 #	FetchContent_MakeAvailable(googlebenchmark googletest)
 #
-#	add_executable(sabre_benchmark benchmark.cpp benchmark_common.h)
-#	add_test(NAME sabre_benchmark COMMAND test)
-#	target_link_libraries(sabre_benchmark PUBLIC benchmark::benchmark)
+#	add_executable(saber_benchmark benchmark.cpp benchmark_common.h)
+#	add_test(NAME saber_benchmark COMMAND test)
+#	target_link_libraries(saber_benchmark PUBLIC benchmark::benchmark)
 #
 #	add_executable(saber_baseline benchmark_baseline.cpp benchmark_common.h)
 #	add_test(NAME saber_baseline COMMAND test)
@@ -60,41 +102,6 @@ endif() # SABER_BUILD_TESTS
 #
 #	add_definitions(-DCATCH_CONFIG_FAST_COMPILE -DWIL_FAST_BUILD)
 #endif() # FAST_BUILD
-
-# All projects need to reference the Saber headers
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
-# Create a customized structure to hold header files when viewed through the IDE
-# Header files will appear in an IDE folder called "Header Files"
-source_group(
-	TREE "include/${PROJECT_SOURCE_DIR}"
-	PREFIX "Header Files"
-	FILES ${HEADER_LIST})
-
-include_directories(BEFORE SYSTEM ${CMAKE_BINARY_DIR}/include)
-
-set(COMMON_SOURCES
-	${CMAKE_CURRENT_SOURCE_DIR}/saber_test.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../natvis/saber.natvis)
-
-# find_package(Catch2 CONFIG REQUIRED)
-link_libraries(Catch2::Catch2WithMain)
-
-set(CMAKE_CXX_STANDARD 17)
-
-if (MSVC)
-	add_definitions(-DNOMINMAX=1 -DWIN32_LEAN_AND_MEAN=1)
-	add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/saber.natvis)
-
-	# For some unknown reason, 'RelWithDebInfo' compiles with '/Ob1' as opposed to '/Ob2' which prevents inlining of
-	# functions not marked 'inline'. The reason we prefer 'RelWithDebInfo' over 'Release' is to get debug info, so manually
-	# revert to the desired (and default) inlining behavior as that exercises more interesting code paths
-	if ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
-		# TODO: This is currently blocked by an apparent Clang bug: https://github.com/llvm/llvm-project/issues/59690
-		# replace_cxx_flag("/Ob1" "/Ob2")
-		replace_cxx_flag("/Ob1" "/Ob2")
-	endif() # STREQUAL "RelWithDebInfo"
-endif() # MSVC
 
 #add_subdirectory(win32)
 #add_subdirectory(osx)

--- a/test/saber_test.cpp
+++ b/test/saber_test.cpp
@@ -1,0 +1,93 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include "catch2/catch_test_macros.hpp"
+
+static int Factorial( int number )
+{
+	return number <= 1 ? number : Factorial( number - 1 ) * number;  // fail
+// return number <= 1 ? 1      : Factorial( number - 1 ) * number;  // pass
+}
+
+TEST_CASE( "Factorial of 0 is 1 (fail)", "[single-file]" )
+{
+	REQUIRE( Factorial(0) == 1 );
+}
+
+TEST_CASE( "Factorials of 1 and higher are computed (pass)", "[single-file]" )
+{
+	REQUIRE( Factorial(1) == 1 );
+	REQUIRE( Factorial(2) == 2 );
+	REQUIRE( Factorial(3) == 6 );
+	REQUIRE( Factorial(10) == 3628800 );
+}
+
+// Compile & run:
+// - g++ -std=c++14 -Wall -I$(CATCH_SINGLE_INCLUDE) -o saber_test saber_test.cpp && saber_test --success
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% saber_test.cpp && saber_test --success
+
+// Expected compact output (all assertions):
+//
+// prompt> saber_test --reporter compact --success
+// saber_test.cpp:14: failed: Factorial(0) == 1 for: 0 == 1
+// saber_test.cpp:18: passed: Factorial(1) == 1 for: 1 == 1
+// saber_test.cpp:19: passed: Factorial(2) == 2 for: 2 == 2
+// saber_test.cpp:20: passed: Factorial(3) == 6 for: 6 == 6
+// saber_test.cpp:21: passed: Factorial(10) == 3628800 for: 3628800 (0x375f00) == 3628800 (0x375f00)
+// Failed 1 test case, failed 1 assertion.
+
+TEST_CASE( "vectors can be sized and resized", "[vector]" )
+{
+	// This setup will be done 4 times in total, once for each section
+	std::vector<int> v( 5 );
+
+	REQUIRE( v.size() == 5 );
+	REQUIRE( v.capacity() >= 5 );
+
+	SECTION( "resizing bigger changes size and capacity" )
+	{
+		v.resize( 10 );
+
+		REQUIRE( v.size() == 10 );
+		REQUIRE( v.capacity() >= 10 );
+	}
+	SECTION( "resizing smaller changes size but not capacity" )
+	{
+		v.resize( 0 );
+
+		REQUIRE( v.size() == 0 );
+		REQUIRE( v.capacity() >= 5 );
+	}
+	SECTION( "reserving bigger changes capacity but not size" )
+	{
+		v.reserve( 10 );
+
+		REQUIRE( v.size() == 5 );
+		REQUIRE( v.capacity() >= 10 );
+	}
+	SECTION( "reserving smaller does not change size or capacity" )
+	{
+		v.reserve( 0 );
+
+		REQUIRE( v.size() == 5 );
+		REQUIRE( v.capacity() >= 5 );
+	}
+	SECTION( "reserving bigger changes capacity but not size" )
+	{
+		v.reserve( 10 );
+
+		REQUIRE( v.size() == 5 );
+		REQUIRE( v.capacity() >= 10 );
+		SECTION( "reserving down unused capacity does not change capacity" )
+		{
+			v.reserve( 7 );
+			REQUIRE( v.size() == 5 );
+			REQUIRE( v.capacity() >= 10 );
+		}
+	}
+}


### PR DESCRIPTION
Add initial cmake build support, for dummy `test/saber_test.exe` target.
Uses 3 cmake variables, that can be configured from `.vscode/settings.json: 'cmake.configureSettings'` to selectively enable:
- `SABER_BUILD_TESTS`: "Build Unit Tests"
- `SABER_BUILD_BENCHMARKS`: "Build Benchmarks"
- `SABER_BUILD_DOCS`: "Build Doxygen Documentation"

Only `SABER_BUILD_TESTS` is currently functional.