### PR TITLE
SABR-10: "CMakeLists.txt doesn't place source and headers into separate IDE folders"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.6)
 
 project(
 	saber
@@ -32,10 +31,16 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-# Include the .natvis files
+include(${PROJECT_SOURCE_DIR}/cmake/cxxflags_common.cmake)
+
+set(CMAKE_CXX_STANDARD 17)
+
 if (MSVC)
+	add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/${PROJECT_NAME}.natvis)
+	# Include the .natvis files
 	target_sources(${PROJECT_NAME} INTERFACE
 		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/natvis/${PROJECT_NAME}.natvis>")
+
 endif() # MSVC
 
 # Install Package Configuration
@@ -53,6 +58,15 @@ if(SABER_BUILD_TESTS)
 	# Must be top-level or test won't be found.
 	include(CTest) # enable_testing() invoked here!
 	add_subdirectory(test)
+
+	if(MSVC)
+		# REVISIT j3fitz 12may2024: Why doesn't `VS_STARTUP_PROJECT` work?
+		# Figure this out later. In the meantime, you must manually set `saber_test`
+		# as `Startup Project`, from within Visual Studio IDE.
+
+		# Set saber_test target as the `startup project` for the generated .sln file
+		set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT saber_test)
+	endif() # MSVC
 endif() # SABER_BUILD_TESTS
 
 # if(SABER_BUILD_DOCS)

--- a/cmake/cxxflags_common.cmake
+++ b/cmake/cxxflags_common.cmake
@@ -14,18 +14,46 @@ endmacro()
 
 # Fixup default compiler settings
 if (MSVC)
-    add_compile_options(
+	# Addn'l -D #defines to make #include<windows.h> less painful
+	add_definitions(-DNOMINMAX=1 -DWIN32_LEAN_AND_MEAN=1)
+	add_compile_options(
         # Be as strict as reasonably possible, since we want to support consumers using strict warning levels
-        /W4 /WX
-        )
-else()
+        /W4 /WX)
+
+	# For some unknown reason, 'RelWithDebInfo' compiles with '/Ob1' as opposed to '/Ob2' which prevents inlining of
+	# functions not marked 'inline'. The reason we prefer 'RelWithDebInfo' over 'Release' is to get debug info, so manually
+	# revert to the desired (and default) inlining behavior as that exercises more interesting code paths
+	if ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+		# TODO: This is currently blocked by an apparent Clang bug: https://github.com/llvm/llvm-project/issues/59690
+		# replace_cxx_flag("/Ob1" "/Ob2")
+		replace_cxx_flag("/Ob1" "/Ob2")
+	endif() # STREQUAL "RelWithDebInfo"
+
+	# Turn on "multi-procssor compilation" switch
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+
+else() # !MSVC
     # Clang with non-MSVC commandline syntax
     add_compile_options(
         # Effectively the same as /W4 /WX
         -Wall -Werror
     )
-endif()
+endif() # !MSVC
 
+# Xcode: Enable some extra debug-facilities for debug builds...
+if(XCODE)
+	if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+		# Generate XCode schema files
+		set(CMAKE_XCODE_GENERATE_SCHEME TRUE)
+		# Make malloc write 0xAA to newly allocated memory and 0x55 to deallocated memory
+		set(CMAKE_XCODE_SCHEME_MALLOC_SCRIBBLE YES)
+		# Place guard pages on each side of large (4096 bytes or more) buffers
+		set(CMAKE_XCODE_SCHEME_MALLOC_GUARD_EDGES YES)
+	endif() # STREQUAL "Debug"
+
+endif() # XCODE
+
+# Clang: Turn off misc warnings...
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(
         # Ignore some pedantic warnings enabled by '-Wextra'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,54 +1,31 @@
+cmake_minimum_required(VERSION 3.6)
+
 message(STATUS "Building saber/test/...")
 
 include(FetchContent)
-include(${PROJECT_SOURCE_DIR}/cmake/cxxflags_common.cmake)
 
-set(CMAKE_CXX_STANDARD 17)
-
-if (MSVC)
-	add_definitions(-DNOMINMAX=1 -DWIN32_LEAN_AND_MEAN=1)
-	add_link_options(/NATVIS:${CMAKE_SOURCE_DIR}/natvis/saber.natvis)
-
-	# For some unknown reason, 'RelWithDebInfo' compiles with '/Ob1' as opposed to '/Ob2' which prevents inlining of
-	# functions not marked 'inline'. The reason we prefer 'RelWithDebInfo' over 'Release' is to get debug info, so manually
-	# revert to the desired (and default) inlining behavior as that exercises more interesting code paths
-	if ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
-		# TODO: This is currently blocked by an apparent Clang bug: https://github.com/llvm/llvm-project/issues/59690
-		# replace_cxx_flag("/Ob1" "/Ob2")
-		replace_cxx_flag("/Ob1" "/Ob2")
-	endif() # STREQUAL "RelWithDebInfo"
-endif() # MSVC
-
+#
+# Saber "unit test" app (saber_test) defined here
+#
 if(SABER_BUILD_TESTS)
 
+	# saber_test depends on `Catch2` test framework
 	FetchContent_Declare(
 		Catch2
 		GIT_REPOSITORY	https://github.com/catchorg/Catch2.git
 		GIT_TAG			v3.6.0)
-
 	FetchContent_MakeAvailable(Catch2)
 
+	# saber_test source files...
 	set(SOURCE_FILES
+#		${CMAKE_CURRENT_SOURCE_DIR}/handler.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/saber_test.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
-	add_executable(saber_test ${SOURCE_FILES})
-
-	# Saber unittest source files will appear in an IDE folder called "test"
-	source_group(
-		TREE "${PROJECT_SOURCE_DIR}/test"
-		PREFIX "test"
-		FILES ${SOURCE_FILES})	
-
-	# All projects need to reference the Saber headers
-	include_directories(${PROJECT_SOURCE_DIR}/include)
-
-	# Create a customized structure to hold header files when viewed through the IDE
-	# Saber header files will appear in an IDE folder called "include/saber"
-	source_group(
-		TREE "${PROJECT_SOURCE_DIR}/include"
-		PREFIX "include"
-		FILES ${HEADER_FILES})
+	add_executable(saber_test
+		${HEADER_FILES}
+		${SOURCE_FILES}
+		${PROJECT_SOURCE_DIR}/CMakeLists.txt)
 
 	include_directories(BEFORE SYSTEM ${CMAKE_BINARY_DIR}/include)
 
@@ -60,6 +37,25 @@ if(SABER_BUILD_TESTS)
 	target_link_libraries(saber_test PRIVATE Catch2 Catch2WithMain)
 	add_test(NAME saber_test COMMAND test)
 
+	# Make the Visual Studio .vcxproj files look prettier...
+	if(MSVC)
+		# TRICKY jfitz 12may2024: Making `source_groups` appear in the VS IDE
+		# A `source_group` directive will only take effect if the FILES
+		# specified are also dependencies of the `add_executable`
+
+		# Source files will appear in an IDE folder called "test"
+		source_group(
+			TREE "${PROJECT_SOURCE_DIR}/test"
+			PREFIX "test"
+			FILES ${SOURCE_FILES})	
+
+		# Header files will appear in an IDE folder called "include"
+		source_group(
+			TREE "${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}"
+			PREFIX "include/${PROJECT_NAME}"
+			FILES ${HEADER_FILES})
+
+	endif() # MSVC
 endif() # SABER_BUILD_TESTS
 
 #if(SABER_BUILD_BENCHMARKS)
@@ -93,7 +89,7 @@ endif() # SABER_BUILD_TESTS
 #endif() # SABER_BUILD_BENCHMARKS
 
 # The build pipelines have limitations that local development environments do not, so turn a few knobs
-#if (${FAST_BUILD})
+#if(${FAST_BUILD})
 #	if (MSVC)
 #		replace_cxx_flag("/GR" "/GR-") # Disables RTTI
 #	else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,9 +18,8 @@ if(SABER_BUILD_TESTS)
 
 	# saber_test source files...
 	set(SOURCE_FILES
-#		${CMAKE_CURRENT_SOURCE_DIR}/handler.cpp
-		${CMAKE_CURRENT_SOURCE_DIR}/saber_test.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/handler.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/saber_test.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
 	add_executable(saber_test


### PR DESCRIPTION
Fixed cmake `source_group` directive usage so that separate folders for source(.cpp) and header(.hpp) files are now shown in VisualStudio IDE. Also added `/MP` (multi-processor compile) support when building with MSVC... so builds are now faster.