### PR TITLE
SABR-16: "ValueHandler ctor{}: what about &&rvalue targets?"

### DIFF
--- a/include/saber/handler.hpp
+++ b/include/saber/handler.hpp
@@ -73,6 +73,10 @@ public:
         mValue = std::move(inNewValue);
     }
 
+    /// @brief Allowing for a R-Value to be input as an L-Value is a bug, since the R-Value goes out of scope 
+    /// immediately and the valuehandler cannot outlive the reference provided
+    ValueHandler(T&& inValue, T inNewValue) = delete;
+
     ~ValueHandler()
     {
         Reset(); // called by dtor: Must be noexcept

--- a/test/handler_unittest.cpp
+++ b/test/handler_unittest.cpp
@@ -77,6 +77,7 @@ TEST_CASE("saber::ValueHandler", "[saber]")
 		REQUIRE(test1 == 0);
 		
 		saber::ValueHandler<int> testHandler{ test1, 10 };
+		//saber::ValueHandler<int> failHandler{int{3}, 10};
 		REQUIRE(test1 == 10);
 		
 		testHandler.Reset();


### PR DESCRIPTION
Fixed ValueHandler ctor preventing handling of RValues