### PR TITLE
SABR-26: "Create `EqualityOperators<>` "operators" for saber geometry"

### DIFF
--- a/include/saber/geometry/operators.hpp
+++ b/include/saber/geometry/operators.hpp
@@ -91,6 +91,28 @@ inline constexpr T operator/(const T& inLHS, const T& inRHS)
     return result;
 }
 
+template<typename T>
+inline constexpr bool operator==(const T& inLHS, const T& inRHS)
+{
+    // Incomprehensible c++ incantation to detect if T implements IsEqual()
+    constexpr bool kHasOperatorEqual = std::is_same_v<bool, decltype(std::declval<T&>().IsEqual(std::declval<T>()))>;
+    static_assert(kHasOperatorEqual, "T does not support operator==");
+
+    const bool result = inLHS.IsEqual(inRHS);
+    return result;
+}
+
+template<typename T>
+inline constexpr bool operator!=(const T& inLHS, const T& inRHS)
+{
+    // Incomprehensible c++ incantation to detect if T implements IsEqual()
+    constexpr bool kHasOperatorEqual = std::is_same_v<bool, decltype(std::declval<T&>().IsEqual(std::declval<T>()))>;
+    static_assert(kHasOperatorEqual, "T does not support operator!=");
+
+    const bool result = !inLHS.IsEqual(inRHS);
+    return result;
+}
+
 } // namespace saber::geometry
 
 #endif //SABER_GEOMETRY_OPERATORS_HPP

--- a/include/saber/geometry/point.hpp
+++ b/include/saber/geometry/point.hpp
@@ -15,7 +15,7 @@ namespace saber::geometry {
 // 3. Has-a: naked types or std::tuple or std::array
 
 template<typename T>
-class Point
+class Point //: private EqualityOperators<Point<T>> // CRTP Curiously Recurring Template Pattern
 {
 public: 
     constexpr Point(T inX, T inY);
@@ -38,6 +38,11 @@ public:
     constexpr Point& operator-=(const Point& inPoint);
     constexpr Point& operator*=(const Point& inPoint);
     constexpr Point& operator/=(const Point& inPoint);
+
+private:
+    constexpr bool IsEqual(const Point& inPoint) const;
+    friend constexpr bool operator==<Point>(const Point& inLHS, const Point& inRHS);
+    friend constexpr bool operator!=<Point>(const Point& inLHS, const Point& inRHS);
 
     // REVISIT mnfitz 15jun2024:
     // Figure out operators supporting scalar operations
@@ -103,36 +108,18 @@ inline constexpr Point<T>& Point<T>::operator/=(const Point& inPoint)
     return *this;
 }
 
-// Class Related Functions
 template<typename T>
-inline bool operator==(const Point<T>& inLHS, const Point<T>& inRHS)
+inline constexpr bool Point<T>::IsEqual(const Point& inPoint) const
 {
     bool result = false;
     if constexpr (std::is_floating_point_v<T>)
     {
-        result = Inexact::IsEq(inLHS.X(), inRHS.X()) && Inexact::IsEq(inLHS.Y(), inRHS.Y());
+        result = Inexact::IsEq(X(), inPoint.X()) && Inexact::IsEq(Y(), inPoint.Y());
     }
     else
     {
-        result = (inLHS.X() == inRHS.X()) && (inLHS.Y() == inRHS.Y());
+        result = (X() == inPoint.X()) && (Y() == inPoint.Y());
     }
-
-    return result;
-}
-
-template<typename T>
-inline bool operator!=(const Point<T>& inLHS, const Point<T>& inRHS)
-{
-    bool result = false;
-    if constexpr (std::is_floating_point_v<T>)
-    {
-        result = Inexact::IsNe(inLHS.X(), inRHS.X()) || Inexact::IsNe(inLHS.Y(), inRHS.Y());
-    }
-    else
-    {
-        result = (inLHS.X() != inRHS.X()) || (inLHS.Y() != inRHS.Y());
-    }
-    
     return result;
 }
 

--- a/include/saber/geometry/point.hpp
+++ b/include/saber/geometry/point.hpp
@@ -15,7 +15,7 @@ namespace saber::geometry {
 // 3. Has-a: naked types or std::tuple or std::array
 
 template<typename T>
-class Point //: private EqualityOperators<Point<T>> // CRTP Curiously Recurring Template Pattern
+class Point // CRTP Curiously Recurring Template Pattern
 {
 public: 
     constexpr Point(T inX, T inY);

--- a/include/saber/geometry/point.hpp
+++ b/include/saber/geometry/point.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 // saber
+#include "saber/inexact.hpp"
 #include "saber/geometry/operators.hpp"
 
 namespace saber::geometry {
@@ -106,14 +107,32 @@ inline constexpr Point<T>& Point<T>::operator/=(const Point& inPoint)
 template<typename T>
 inline bool operator==(const Point<T>& inLHS, const Point<T>& inRHS)
 {
-    bool result = (inLHS.X() == inRHS.X()) && (inLHS.Y() == inRHS.Y());
+    bool result = false;
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        result = Inexact::IsEq(inLHS.X(), inRHS.X()) && Inexact::IsEq(inLHS.Y(), inRHS.Y());
+    }
+    else
+    {
+        result = (inLHS.X() == inRHS.X()) && (inLHS.Y() == inRHS.Y());
+    }
+
     return result;
 }
 
 template<typename T>
 inline bool operator!=(const Point<T>& inLHS, const Point<T>& inRHS)
 {
-    bool result = !(inLHS == inRHS);
+    bool result = false;
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        result = Inexact::IsNe(inLHS.X(), inRHS.X()) || Inexact::IsNe(inLHS.Y(), inRHS.Y());
+    }
+    else
+    {
+        result = (inLHS.X() != inRHS.X()) || (inLHS.Y() != inRHS.Y());
+    }
+    
     return result;
 }
 

--- a/include/saber/geometry/size.hpp
+++ b/include/saber/geometry/size.hpp
@@ -16,7 +16,7 @@ namespace saber::geometry {
 // 5. Build up binary free operators from class operators +=, etc
 
 template<typename T>
-class Size 
+class Size //: private EqualityOperators<Size<T>> // CRTP Curiously Recurring Template Pattern
 {
 public: 
     constexpr Size(T inWidth, T inHeight);
@@ -39,6 +39,11 @@ public:
     constexpr Size& operator-=(const Size& inSize);
     constexpr Size& operator*=(const Size& inSize);
     constexpr Size& operator/=(const Size& inSize);
+
+private:
+    constexpr bool IsEqual(const Size& inSize) const;
+    friend constexpr bool operator==<Size>(const Size& inLHS, const Size& inRHS);
+    friend constexpr bool operator!=<Size>(const Size& inLHS, const Size& inRHS);
 
     // REVISIT mnfitz 15jun2024:
     // Figure out operators supporting scalar operations
@@ -104,18 +109,18 @@ inline constexpr Size<T>& Size<T>::operator/=(const Size& inSize)
     return *this;
 }
 
-// Class Related Functions
 template<typename T>
-inline bool operator==(const Size<T>& inLHS, const Size<T>& inRHS)
+inline constexpr bool Size<T>::IsEqual(const Size& inSize) const
 {
-    bool result = (inLHS.Width() == inRHS.Width()) && (inLHS.Height() == inRHS.Height());
-    return result;
-}
-
-template<typename T>
-inline bool operator!=(const Size<T>& inLHS, const Size<T>& inRHS)
-{
-    bool result = !(inLHS == inRHS);
+    bool result = false;
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        result = Inexact::IsEq(Width(), inSize.Width()) && Inexact::IsEq(Height(), inSize.Height());
+    }
+    else
+    {
+        result = (Width() == inSize.Width()) && (Height() == inSize.Height());
+    }
     return result;
 }
 

--- a/include/saber/inexact.hpp
+++ b/include/saber/inexact.hpp
@@ -37,7 +37,6 @@ public:
         Eq(const T& inLHS) :
             mLHS{inLHS}
         {
-            //constexpr bool isFloatingPoint = std::is_floating_point<T>::value;
             constexpr bool isFloatingPoint = std::is_floating_point_v<T>;
             static_assert(isFloatingPoint, "Eq only supports floating point types");
         };

--- a/test/geometry_unittest.cpp
+++ b/test/geometry_unittest.cpp
@@ -228,18 +228,28 @@ TEST_CASE("saber::geometry::operators Size", "[saber]")
 
 	SECTION("Size == Size")
 	{
-		saber::geometry::Size<int> Size1{1,2};
-		saber::geometry::Size<int> Size2{1,2};
-		auto result = Size1 == Size2;
+		saber::geometry::Size<int> size1{1,2};
+		saber::geometry::Size<int> size2{1,2};
+		auto result = size1 == size2;
 		REQUIRE(result);
+
+		saber::geometry::Size<double> size3{1.0,2.0};
+		saber::geometry::Size<double> size4{1.0,2.0};
+		auto result2 = size3 == size4;
+		REQUIRE(result2);
 	}
 
 	SECTION("Size != Size")
 	{
-		saber::geometry::Size<int> Size1{1,2};
-		saber::geometry::Size<int> Size2{2,4};
-		auto result = Size1 != Size2;
+		saber::geometry::Size<int> size1{1,2};
+		saber::geometry::Size<int> size2{2,2};
+		auto result = size1 != size2;
 		REQUIRE(result);
+
+		saber::geometry::Size<double> size3{1.0,2.0};
+		saber::geometry::Size<double> size4{2.0,2.0};
+		auto result2 = size3 != size4;
+		REQUIRE(result2);
 	}
 }
 
@@ -247,90 +257,100 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 {
 	SECTION("Point += Point")
 	{
-		saber::geometry::Point<int> Point1{1,2};
-		saber::geometry::Point<int> Point2{1,2};
-		Point1 += Point2;
-		REQUIRE(Point1.X() == 2);
-		REQUIRE(Point1.Y() == 4);
+		saber::geometry::Point<int> point1{1,2};
+		saber::geometry::Point<int> point2{1,2};
+		point1 += point2;
+		REQUIRE(point1.X() == 2);
+		REQUIRE(point1.Y() == 4);
 	}
 
 	SECTION("Point -= Point")
 	{
-		saber::geometry::Point<int> Point1{2,4};
-		saber::geometry::Point<int> Point2{1,2};
-		Point1 -= Point2;
-		REQUIRE(Point1.X() == 1);
-		REQUIRE(Point1.Y() == 2);
+		saber::geometry::Point<int> point1{2,4};
+		saber::geometry::Point<int> point2{1,2};
+		point1 -= point2;
+		REQUIRE(point1.X() == 1);
+		REQUIRE(point1.Y() == 2);
 	}
 
 	SECTION("Point *= Point")
 	{
-		saber::geometry::Point<int> Point1{1,2};
-		saber::geometry::Point<int> Point2{1,2};
-		Point1 *= Point2;
-		REQUIRE(Point1.X() == 1);
-		REQUIRE(Point1.Y() == 4);
+		saber::geometry::Point<int> point1{1,2};
+		saber::geometry::Point<int> point2{1,2};
+		point1 *= point2;
+		REQUIRE(point1.X() == 1);
+		REQUIRE(point1.Y() == 4);
 	}
 
 	SECTION("Point /= Point")
 	{
-		saber::geometry::Point<int> Point1{2,4};
-		saber::geometry::Point<int> Point2{1,2};
-		Point1 /= Point2;
-		REQUIRE(Point1.X() == 2);
-		REQUIRE(Point1.Y() == 2);
+		saber::geometry::Point<int> point1{2,4};
+		saber::geometry::Point<int> point2{1,2};
+		point1 /= point2;
+		REQUIRE(point1.X() == 2);
+		REQUIRE(point1.Y() == 2);
 	}
 
 	SECTION("Point + Point")
 	{
-		constexpr saber::geometry::Point<int> Point1{1,2};
-		constexpr saber::geometry::Point<int> Point2{1,2};
-		constexpr auto result = Point1 + Point2;
+		constexpr saber::geometry::Point<int> point1{1,2};
+		constexpr saber::geometry::Point<int> point2{1,2};
+		constexpr auto result = point1 + point2;
 		REQUIRE(result.X() == 2);
 		REQUIRE(result.Y() == 4);
 	}
 
 	SECTION("Point - Point")
 	{
-		constexpr saber::geometry::Point<int> Point1{2,4};
-		constexpr saber::geometry::Point<int> Point2{1,2};
-		constexpr auto result = Point1 - Point2;
+		constexpr saber::geometry::Point<int> point1{2,4};
+		constexpr saber::geometry::Point<int> point2{1,2};
+		constexpr auto result = point1 - point2;
 		REQUIRE(result.X() == 1);
 		REQUIRE(result.Y() == 2);
 	}
 
 	SECTION("Point * Point")
 	{
-		constexpr saber::geometry::Point<int> Point1{1,2};
-		constexpr saber::geometry::Point<int> Point2{1,2};
-		constexpr auto result = Point1 * Point2;
+		constexpr saber::geometry::Point<int> point1{1,2};
+		constexpr saber::geometry::Point<int> point2{1,2};
+		constexpr auto result = point1 * point2;
 		REQUIRE(result.X() == 1);
 		REQUIRE(result.Y() == 4);
 	}
 
 	SECTION("Point / Point")
 	{
-		constexpr saber::geometry::Point<int> Point1{2,4};
-		constexpr saber::geometry::Point<int> Point2{1,2};
-		constexpr auto result = Point1 / Point2;
+		saber::geometry::Point<int> point1{2,4};
+		saber::geometry::Point<int> point2{1,2};
+		auto result = point1 / point2;
 		REQUIRE(result.X() == 2);
 		REQUIRE(result.Y() == 2);
 	}
 
 	SECTION("Point == Point")
 	{
-		saber::geometry::Point<int> Point1{1,2};
-		saber::geometry::Point<int> Point2{1,2};
-		auto result = Point1 == Point2;
+		saber::geometry::Point<int> point1{1,2};
+		saber::geometry::Point<int> point2{1,2};
+		auto result = point1 == point2;
 		REQUIRE(result);
+
+		saber::geometry::Point<float> point3{1.0f,2.0f};
+		saber::geometry::Point<float> point4{1.0f,2.0f};		
+		auto result2 = point3 == point4;
+		REQUIRE(result2);
 	}
 
 	SECTION("Point != Point")
 	{
-		saber::geometry::Point<int> Point1{1,2};
-		saber::geometry::Point<int> Point2{2,4};
-		auto result = Point1 != Point2;
+		saber::geometry::Point<int> point1{1,2};
+		saber::geometry::Point<int> point2{2,4};
+		auto result = point1 != point2;
 		REQUIRE(result);
+
+		saber::geometry::Point<float> point3{1.0f,2.0f};
+		saber::geometry::Point<float> point4{2.0f,4.0f};
+		auto result2 = point3 != point4;
+		REQUIRE(result2);
 	}
 }
 


### PR DESCRIPTION
Changed Point to use inexact comparisons on floating point values.