### PR TITLE
SABR-37: "Augment `Point` and `Size` classes w/ `Translate()` and `Scale()` capability"

### DIFF
--- a/include/saber/geometry/point.hpp
+++ b/include/saber/geometry/point.hpp
@@ -141,7 +141,7 @@ inline constexpr Point<T, ImplType> Translate(const Point<T, ImplType>& inPoint,
 template<typename T, typename ImplType>
 inline constexpr Point<T, ImplType> Translate(const Point<T, ImplType>& inPoint, T inX, T inY)
 {
-    Point<T, ImplType> translate{inX, inY};
+    const Point<T, ImplType> translate{inX, inY};
     return Translate(inPoint, translate);
 }
 
@@ -155,14 +155,14 @@ template<typename T, typename ImplType>
 inline constexpr Point<T, ImplType> Scale(const Point<T, ImplType>& inPoint, const Point<T, ImplType>& inScale)
 {
     Point<T, ImplType> result{inPoint};
-    result += inScale;
+    result *= inScale;
     return result;
 }
 
 template<typename T, typename ImplType>
 inline constexpr Point<T, ImplType> Scale(const Point<T, ImplType>& inPoint, T inScaleX, T inScaleY)
 {
-    Point<T, ImplType> scale{inScaleX, inScaleY};
+    const Point<T, ImplType> scale{inScaleX, inScaleY};
     return Scale(inPoint, scale);
 }
 

--- a/include/saber/geometry/point.hpp
+++ b/include/saber/geometry/point.hpp
@@ -47,8 +47,12 @@ public:
     constexpr Point& operator*=(const Point& inPoint);
     constexpr Point& operator/=(const Point& inPoint);
 
+// Private APIs
 private:
     constexpr bool IsEqual(const Point& inPoint) const;
+
+// Friend functions
+private:
     friend constexpr bool operator==<Point>(const Point& inLHS, const Point& inRHS);
     friend constexpr bool operator!=<Point>(const Point& inLHS, const Point& inRHS);
 
@@ -59,7 +63,7 @@ private:
     ImplType mImpl{};
 }; // class Point<>
 
-// Inline Class Functions
+// Inline Class Methods
 
 template<typename T, typename ImplType>
 inline constexpr Point<T, ImplType>::Point(T inX, T inY) :
@@ -123,6 +127,49 @@ inline constexpr bool Point<T, ImplType>::IsEqual(const Point& inPoint) const
         result = (X() == inPoint.X()) && (Y() == inPoint.Y());
     }
     return result;
+}
+
+// Free functions 
+template<typename T, typename ImplType>
+inline constexpr Point<T, ImplType> Translate(const Point<T, ImplType>& inPoint, const Point<T, ImplType>& inTranslate)
+{
+    Point<T, ImplType> result{inPoint};
+    result += inTranslate;
+    return result;
+}
+
+template<typename T, typename ImplType>
+inline constexpr Point<T, ImplType> Translate(const Point<T, ImplType>& inPoint, T inX, T inY)
+{
+    Point<T, ImplType> translate{inX, inY};
+    return Translate(inPoint, translate);
+}
+
+template<typename T, typename ImplType>
+inline constexpr Point<T, ImplType> Translate(const Point<T, ImplType>& inPoint, T inTranslate)
+{
+    return Translate(inPoint, inTranslate, inTranslate);
+}
+
+template<typename T, typename ImplType>
+inline constexpr Point<T, ImplType> Scale(const Point<T, ImplType>& inPoint, const Point<T, ImplType>& inScale)
+{
+    Point<T, ImplType> result{inPoint};
+    result += inScale;
+    return result;
+}
+
+template<typename T, typename ImplType>
+inline constexpr Point<T, ImplType> Scale(const Point<T, ImplType>& inPoint, T inScaleX, T inScaleY)
+{
+    Point<T, ImplType> scale{inScaleX, inScaleY};
+    return Scale(inPoint, scale);
+}
+
+template<typename T, typename ImplType>
+inline constexpr Point<T, ImplType> Scale(const Point<T, ImplType>& inPoint, T inScale)
+{
+    return Scale(inPoint, inScale, inScale);
 }
 
 // TRICKY mnfitz 14oct2024: Turn on structured binging support for C++17 or later

--- a/include/saber/geometry/size.hpp
+++ b/include/saber/geometry/size.hpp
@@ -53,7 +53,8 @@ private:
     //T mHeight{};
 }; // class size
 
-// Inline Class Functions
+// ------------------------------------------------------------------
+#pragma region Inline Class Functions
 
 template<typename T, typename ImplType>
 inline constexpr Size<T, ImplType>::Size(T inWidth, T inHeight) :
@@ -74,7 +75,11 @@ inline constexpr T Size<T, ImplType>::Height() const
     return mImpl.Get<1>();
 }
 
-// Mathematical operations
+#pragma endregion
+
+// ------------------------------------------------------------------
+#pragma region Inline Mathematical operations
+
 template<typename T, typename ImplType>
 inline constexpr Size<T, ImplType>& Size<T, ImplType>::operator+=(const Size& inSize)
 {
@@ -118,10 +123,60 @@ inline constexpr bool Size<T, ImplType>::IsEqual(const Size& inSize) const
     return result;
 }
 
+#pragma endregion
+
+// ------------------------------------------------------------------
+#pragma region Free Functions
+
+template<typename T, typename ImplType>
+inline constexpr Size<T, ImplType> Enlarge(const Size<T, ImplType>& inSize, const Size<T, ImplType>& inMagnitude)
+{
+    Size<T, ImplType> result{inSize};
+    result += inMagnitude;
+    return result;
+}
+
+template<typename T, typename ImplType>
+inline constexpr Size<T, ImplType> Enlarge(const Size<T, ImplType>& inSize, T inX, T inY)
+{
+    const Size<T, ImplType> magnitude{inX, inY};
+    return Enlarge(inSize, magnitude);
+}
+
+template<typename T, typename ImplType>
+inline constexpr Size<T, ImplType> Enlarge(const Size<T, ImplType>& inSize, T inMagnitude)
+{
+    return Enlarge(inSize, inMagnitude, inMagnitude);
+}
+
+template<typename T, typename ImplType>
+inline constexpr Size<T, ImplType> Scale(const Size<T, ImplType>& inSize, const Size<T, ImplType>& inScale)
+{
+    Size<T, ImplType> result{inSize};
+    result *= inScale;
+    return result;
+}
+
+template<typename T, typename ImplType>
+inline constexpr Size<T, ImplType> Scale(const Size<T, ImplType>& inSize, T inScaleX, T inScaleY)
+{
+    const Size<T, ImplType> scale{inScaleX, inScaleY};
+    return Scale(inSize, scale);
+}
+
+template<typename T, typename ImplType>
+inline constexpr Size<T, ImplType> Scale(const Size<T, ImplType>& inSize, T inScale)
+{
+    return Scale(inSize, inScale, inScale);
+}
+
+#pragma endregion 
+
+// ------------------------------------------------------------------
+#pragma region Structured Bindings
+
 // TRICKY mnfitz 14oct2024: Turn on structured binging support for C++17 or later
 #ifdef __cpp_structured_bindings
-
-// Structured Binding Support
 
 // Prefer free function over class method
 template<std::size_t Index, typename T>
@@ -157,6 +212,7 @@ struct std::tuple_element<Index, Size<T>> // Partial template specialization for
 };
 
 #endif // __cpp_structured_bindings
+#pragma endregion
 
 }// namespace saber::geometry
 

--- a/test/geometry_unittest.cpp
+++ b/test/geometry_unittest.cpp
@@ -457,6 +457,142 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 		auto result2 = point3 != point4;
 		REQUIRE(result2);
 	}
+
+	SECTION("Translate Point -> Point")
+	{
+		saber::geometry::Point<int> point1{1,2};
+		saber::geometry::Point<int> point2{2,4};
+
+		saber::geometry::Point<int> expected{3,6};
+
+		auto result = saber::geometry::Translate(point1, point2) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Translate Point -> X, Y")
+	{
+		saber::geometry::Point<int> point1{1,2};
+		const int x = 2;
+		const int y = 4;
+
+		saber::geometry::Point<int> expected{3,6};
+
+		auto result = saber::geometry::Translate(point1, x, y) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Translate Point -> X")
+	{
+		saber::geometry::Point<int> point1{1,2};
+		const int x = 2; 
+
+		saber::geometry::Point<int> expected{3,4};
+
+		auto result = saber::geometry::Translate(point1, x) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Scale Point -> Point")
+	{
+		saber::geometry::Point<int> point1{1,2};
+		saber::geometry::Point<int> point2{2,4};
+
+		saber::geometry::Point<int> expected{2,8};
+
+		auto result = saber::geometry::Scale(point1, point2) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Scale Point -> X, Y")
+	{
+		saber::geometry::Point<int> point1{1,2};
+		const int x = 2;
+		const int y = 4;
+
+		saber::geometry::Point<int> expected{2,8};
+
+		auto result = saber::geometry::Scale(point1, x, y) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Scale Point -> X")
+	{
+		saber::geometry::Point<int> point1{1,2};
+		const int x = 2;
+
+		saber::geometry::Point<int> expected{2,4};
+
+		auto result = saber::geometry::Scale(point1, x) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Enlarge Size -> Size")
+	{
+		saber::geometry::Size<int> size1{1,2};
+		saber::geometry::Size<int> size2{2,4};
+
+		saber::geometry::Size<int> expected{3,6};
+
+		auto result = saber::geometry::Enlarge(size1, size2) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Enlarge Size -> X, Y")
+	{
+		saber::geometry::Size<int> size1{1,2};
+		const int x = 2;
+		const int y = 4;
+
+		saber::geometry::Size<int> expected{3,6};
+
+		auto result = saber::geometry::Enlarge(size1, x, y) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Enlarge Size -> X")
+	{
+		saber::geometry::Size<int> size1{1,2};
+		const int x = 2; 
+
+		saber::geometry::Size<int> expected{3,4};
+
+		auto result = saber::geometry::Enlarge(size1, x) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Scale Size -> Size")
+	{
+		saber::geometry::Size<int> size1{1,2};
+		saber::geometry::Size<int> size2{2,4};
+
+		saber::geometry::Size<int> expected{2,8};
+
+		auto result = saber::geometry::Scale(size1, size2) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Scale Size -> X, Y")
+	{
+		saber::geometry::Size<int> size1{1,2};
+		const int x = 2;
+		const int y = 4;
+
+		saber::geometry::Size<int> expected{2,8};
+
+		auto result = saber::geometry::Scale(size1, x, y) == expected;
+		REQUIRE(result);
+	}
+
+	SECTION("Scale Size -> X")
+	{
+		saber::geometry::Size<int> size1{1,2};
+		const int x = 2;
+
+		saber::geometry::Size<int> expected{2,4};
+
+		auto result = saber::geometry::Scale(size1, x) == expected;
+		REQUIRE(result);
+	}
 }
 
 TEST_CASE("saber::geometry::Inexact::Eq float", "[saber]")


### PR DESCRIPTION
Added translate and scale free functions to point