### PR TITLE
SABR-40: "'RoundNearest()`/SSE rounds to "nearest even" instead of "nearest"

### DIFF
--- a/include/saber/geometry/detail/simd_sse.hpp
+++ b/include/saber/geometry/detail/simd_sse.hpp
@@ -288,13 +288,18 @@ using typename SimdTraits<128, float>::SimdType; // Expose `SimdType` as our own
 		return approxEq;
 	}
 
-	/// @brief Round all <float> values toward the nearest even number
+	/// @brief Round all <float> values toward the nearest whole number
 	/// @param inRound Input to be rounded
 	/// @return Return rounded SimdType values
 	static SimdType RoundNearest(SimdType inRound)
 	{
-		auto round = _mm_round_ps(inRound, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
-		return round;
+		auto cmpge = _mm_cmpge_ps(inRound, _mm_setzero_ps());
+		const auto add = _mm_set_ps(0.5f, 0.5f, 0.5f, 0.5f);
+		const auto sub = _mm_set_ps(-0.5f, -0.5f, -0.5f, -0.5f);
+
+		auto byHalf = _mm_blendv_ps(sub, add, cmpge);
+		auto round = _mm_add_ps(inRound, byHalf);
+		return RoundTrunc(round);
 	}
 
 	/// @brief Round all <float> values toward positive infinity
@@ -478,7 +483,39 @@ using typename SimdTraits<128, double>::SimdType; // Expose `SimdType` as our ow
 	/// @return Return rounded SimdType values
 	static SimdType RoundNearest(SimdType inRound)
 	{
-		auto round = _mm_round_pd(inRound, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+		auto cmpge = _mm_cmpge_pd(inRound, _mm_setzero_pd());
+		const auto add = _mm_set_pd(0.5, 0.5);
+		const auto sub = _mm_set_pd(-0.5, -0.5);
+
+		auto byHalf = _mm_blendv_pd(sub, add, cmpge);
+		auto round = _mm_add_pd(inRound, byHalf);
+		return RoundTrunc(round);
+	}
+
+	/// @brief Round all <double> values toward positive infinity
+	/// @param inRound Input to be rounded
+	/// @return Return rounded SimdType values
+	static SimdType RoundCeil(SimdType inRound)
+	{
+		auto round = _mm_round_pd(inRound, _MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC);
+		return round;
+	}
+
+	/// @brief Round all <double> values toward negative infinity
+	/// @param inRound Input to be rounded
+	/// @return Return rounded SimdType values
+	static SimdType RoundFloor(SimdType inRound)
+	{
+		auto round = _mm_round_pd(inRound, _MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC);
+		return round;
+	}
+
+	/// @brief Round all <double> values toward zero
+	/// @param inRound Input to be rounded
+	/// @return Return rounded SimdType values
+	static SimdType RoundTrunc(SimdType inRound)
+	{
+		auto round = _mm_round_pd(inRound, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 		return round;
 	}
 };

--- a/include/saber/geometry/detail/simd_sse.hpp
+++ b/include/saber/geometry/detail/simd_sse.hpp
@@ -293,12 +293,11 @@ using typename SimdTraits<128, float>::SimdType; // Expose `SimdType` as our own
 	/// @return Return rounded SimdType values
 	static SimdType RoundNearest(SimdType inRound)
 	{
-		auto cmpge = _mm_cmpge_ps(inRound, _mm_setzero_ps());
-		const auto add = _mm_set_ps(0.5f, 0.5f, 0.5f, 0.5f);
-		const auto sub = _mm_set_ps(-0.5f, -0.5f, -0.5f, -0.5f);
+		const auto pos = _mm_set_ps(0.5f, 0.5f, 0.5f, 0.5f);
+		const auto neg = _mm_set_ps(-0.5f, -0.5f, -0.5f, -0.5f);
 
-		auto byHalf = _mm_blendv_ps(sub, add, cmpge);
-		auto round = _mm_add_ps(inRound, byHalf);
+		const auto byHalf = _mm_blendv_ps(pos, neg, inRound);
+		const auto round = _mm_add_ps(inRound, byHalf);
 		return RoundTrunc(round);
 	}
 
@@ -483,12 +482,11 @@ using typename SimdTraits<128, double>::SimdType; // Expose `SimdType` as our ow
 	/// @return Return rounded SimdType values
 	static SimdType RoundNearest(SimdType inRound)
 	{
-		auto cmpge = _mm_cmpge_pd(inRound, _mm_setzero_pd());
-		const auto add = _mm_set_pd(0.5, 0.5);
-		const auto sub = _mm_set_pd(-0.5, -0.5);
+		const auto pos = _mm_set_pd(0.5, 0.5);
+		const auto neg = _mm_set_pd(-0.5, -0.5);
 
-		auto byHalf = _mm_blendv_pd(sub, add, cmpge);
-		auto round = _mm_add_pd(inRound, byHalf);
+		const auto byHalf = _mm_blendv_pd(pos, neg, inRound);
+		const auto round = _mm_add_pd(inRound, byHalf);
 		return RoundTrunc(round);
 	}
 

--- a/test/geometry_unittest.cpp
+++ b/test/geometry_unittest.cpp
@@ -604,24 +604,27 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 	{
 		saber::geometry::Point<float> point1{1.1f, -2.9f};
 		saber::geometry::Point<float> expected1{1.0f, -3.0f};
-		saber::geometry::Point<float> point2{1.9f, -2.1f};
-		saber::geometry::Point<float> expected2{2.0f, -2.0f};
-		saber::geometry::Point<float> point3{1.5f, -3.5f};
-		saber::geometry::Point<float> expected3{2.0f, -4.0f};
-
 		auto roundPoint1 = saber::geometry::RoundNearest(point1);
 		point1.RoundNearest();
-		auto result1 = roundPoint1 == expected1 && point1 == expected1;
+		REQUIRE((roundPoint1 == expected1 && point1 == expected1));
+
+		saber::geometry::Point<float> point2{1.9f, -2.1f};
+		saber::geometry::Point<float> expected2{2.0f, -2.0f};
 		auto roundPoint2 = saber::geometry::RoundNearest(point2);
 		point2.RoundNearest();
-		auto result2 = roundPoint2 == expected2 && point2 == expected2;
+		REQUIRE((roundPoint2 == expected2 && point2 == expected2));
+
+		saber::geometry::Point<float> point3{1.5f, -3.5f};
+		saber::geometry::Point<float> expected3{2.0f, -4.0f};
 		auto roundPoint3 = saber::geometry::RoundNearest(point3);
 		point3.RoundNearest();
-		auto result3 = roundPoint3 == expected3 && point3 == expected3;
+		REQUIRE((roundPoint3 == expected3 && point3 == expected3));
 
-		REQUIRE(result1);
-		REQUIRE(result2);
-		REQUIRE(result3);
+		saber::geometry::Point<float> point4{2.5f, -2.5f};
+		saber::geometry::Point<float> expected4{3.0f, -3.0f};
+		auto roundPoint4 = saber::geometry::RoundNearest(point4);
+		point4.RoundNearest();
+		REQUIRE((roundPoint4 == expected4 && point4 == expected4));
 	}
 
 	SECTION("RoundTrunc Point")
@@ -768,24 +771,31 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 	{
 		saber::geometry::Size<float> size1{1.1f, -2.9f};
 		saber::geometry::Size<float> expected1{1.0f, -3.0f};
-		saber::geometry::Size<float> size2{1.9f, -2.1f};
-		saber::geometry::Size<float> expected2{2.0f, -2.0f};
-		saber::geometry::Size<float> size3{1.5f, -3.5f};
-		saber::geometry::Size<float> expected3{2.0f, -4.0f};
-
 		auto roundSize1 = saber::geometry::RoundNearest(size1);
 		size1.RoundNearest();
 		auto result1 = roundSize1 == expected1 && size1 == expected1;
+		REQUIRE(result1);
+
+		saber::geometry::Size<float> size2{1.9f, -2.1f};
+		saber::geometry::Size<float> expected2{2.0f, -2.0f};
 		auto roundSize2 = saber::geometry::RoundNearest(size2);
 		size2.RoundNearest();
 		auto result2 = roundSize2 == expected2 && size2 == expected2;
+		REQUIRE(result2);
+
+		saber::geometry::Size<float> size3{1.5f, -3.5f};
+		saber::geometry::Size<float> expected3{2.0f, -4.0f};
 		auto roundSize3 = saber::geometry::RoundNearest(size3);
 		size3.RoundNearest();
 		auto result3 = roundSize3 == expected3 && size3 == expected3;
-
-		REQUIRE(result1);
-		REQUIRE(result2);
 		REQUIRE(result3);
+
+		saber::geometry::Size<float> size4{2.5f, -2.5f};
+		saber::geometry::Size<float> expected4{3.0f, -3.0f};
+		auto roundSize4 = saber::geometry::RoundNearest(size4);
+		size4.RoundNearest();
+		auto result4 = roundSize4 == expected4 && size4 == expected4;
+		REQUIRE(result4);
 	}
 
 	SECTION("RoundTrunc Size")

--- a/test/geometry_unittest.cpp
+++ b/test/geometry_unittest.cpp
@@ -767,7 +767,7 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 		REQUIRE(result);
 	}
 
-	SECTION("RoundNearest Size")
+	SECTION("RoundNearest Size<float>")
 	{
 		saber::geometry::Size<float> size1{1.1f, -2.9f};
 		saber::geometry::Size<float> expected1{1.0f, -3.0f};
@@ -798,7 +798,7 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 		REQUIRE(result4);
 	}
 
-	SECTION("RoundTrunc Size")
+	SECTION("RoundTrunc Size<float>")
 	{
 		saber::geometry::Size<float> size1{1.1f, -2.9f};
 		saber::geometry::Size<float> expected1{1.0f, -2.0f};
@@ -825,7 +825,7 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 		REQUIRE(result3);
 	}
 
-	SECTION("RoundCeil Size")
+	SECTION("RoundCeil Size<float>")
 	{
 		saber::geometry::Size<float> size1{1.1f, -2.9f};
 		saber::geometry::Size<float> expected1{2.0f, -2.0f};
@@ -849,7 +849,7 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 		REQUIRE(result3);
 	}
 
-	SECTION("RoundFloor Size")
+	SECTION("RoundFloor Size<float>")
 	{
 		saber::geometry::Size<float> size1{1.1f, -2.9f};
 		saber::geometry::Size<float> expected1{1.0f, -3.0f};
@@ -857,6 +857,112 @@ TEST_CASE("saber::geometry::operators Point", "[saber]")
 		saber::geometry::Size<float> expected2{1.0f, -3.0f};
 		saber::geometry::Size<float> size3{1.5f, -3.5f};
 		saber::geometry::Size<float> expected3{1.0f, -4.0f};
+
+		auto roundSize1 = saber::geometry::RoundFloor(size1);
+		size1.RoundFloor();
+		auto result1 = roundSize1 == expected1 && size1 == expected1;
+		auto roundSize2 = saber::geometry::RoundFloor(size2);
+		size2.RoundFloor();
+		auto result2 = roundSize2 == expected2 && size2 == expected2;
+		auto roundSize3 = saber::geometry::RoundFloor(size3);
+		size3.RoundFloor();
+		auto result3 = roundSize3 == expected3 && size3 == expected3;
+
+		REQUIRE(result1);
+		REQUIRE(result2);
+		REQUIRE(result3);
+	}
+
+	SECTION("RoundNearest Size<double>")
+	{
+		saber::geometry::Size<double> size1{1.1, -2.9};
+		saber::geometry::Size<double> expected1{1.0, -3.0};
+		auto roundSize1 = saber::geometry::RoundNearest(size1);
+		size1.RoundNearest();
+		auto result1 = roundSize1 == expected1 && size1 == expected1;
+		REQUIRE(result1);
+
+		saber::geometry::Size<double> size2{1.9, -2.1};
+		saber::geometry::Size<double> expected2{2.0, -2.0};
+		auto roundSize2 = saber::geometry::RoundNearest(size2);
+		size2.RoundNearest();
+		auto result2 = roundSize2 == expected2 && size2 == expected2;
+		REQUIRE(result2);
+
+		saber::geometry::Size<double> size3{1.5, -3.5};
+		saber::geometry::Size<double> expected3{2.0, -4.0};
+		auto roundSize3 = saber::geometry::RoundNearest(size3);
+		size3.RoundNearest();
+		auto result3 = roundSize3 == expected3 && size3 == expected3;
+		REQUIRE(result3);
+
+		saber::geometry::Size<double> size4{2.5, -2.5};
+		saber::geometry::Size<double> expected4{3.0, -3.0};
+		auto roundSize4 = saber::geometry::RoundNearest(size4);
+		size4.RoundNearest();
+		auto result4 = roundSize4 == expected4 && size4 == expected4;
+		REQUIRE(result4);
+	}
+
+	SECTION("RoundTrunc Size<double>")
+	{
+		saber::geometry::Size<double> size1{1.1, -2.9};
+		saber::geometry::Size<double> expected1{1.0, -2.0};
+		saber::geometry::Size<double> size2{1.9, -2.1};
+		saber::geometry::Size<double> expected2{1.0, -2.0};
+		saber::geometry::Size<double> size3{1.5, -3.5};
+		saber::geometry::Size<double> expected3{1.0, -3.0};
+
+		//saber::geometry::Size<int> sizeInt{2, -4};
+		//sizeInt.RoundTrunc();
+
+		auto roundSize1 = saber::geometry::RoundTrunc(size1);
+		size1.RoundTrunc();
+		auto result1 = roundSize1 == expected1 && size1 == expected1;
+		auto roundSize2 = saber::geometry::RoundTrunc(size2);
+		size2.RoundTrunc();
+		auto result2 = roundSize2 == expected2 && size2 == expected2;
+		auto roundSize3 = saber::geometry::RoundTrunc(size3);
+		size3.RoundTrunc();
+		auto result3 = roundSize3 == expected3 && size3 == expected3;
+
+		REQUIRE(result1);
+		REQUIRE(result2);
+		REQUIRE(result3);
+	}
+
+	SECTION("RoundCeil Size<double>")
+	{
+		saber::geometry::Size<double> size1{1.1, -2.9};
+		saber::geometry::Size<double> expected1{2.0, -2.0};
+		saber::geometry::Size<double> size2{1.9, -2.1};
+		saber::geometry::Size<double> expected2{2.0, -2.0};
+		saber::geometry::Size<double> size3{1.5, -3.5};
+		saber::geometry::Size<double> expected3{2.0, -3.0};
+
+		auto roundSize1 = saber::geometry::RoundCeil(size1);
+		size1.RoundCeil();
+		auto result1 = roundSize1 == expected1 && size1 == expected1;
+		auto roundSize2 = saber::geometry::RoundCeil(size2);
+		size2.RoundCeil();
+		auto result2 = roundSize2 == expected2 && size2 == expected2;
+		auto roundSize3 = saber::geometry::RoundCeil(size3);
+		size3.RoundCeil();
+		auto result3 = roundSize3 == expected3 && size3 == expected3;
+
+		REQUIRE(result1);
+		REQUIRE(result2);
+		REQUIRE(result3);
+	}
+
+	SECTION("RoundFloor Size<double>")
+	{
+		saber::geometry::Size<double> size1{1.1, -2.9};
+		saber::geometry::Size<double> expected1{1.0, -3.0};
+		saber::geometry::Size<double> size2{1.9, -2.1};
+		saber::geometry::Size<double> expected2{1.0, -3.0};
+		saber::geometry::Size<double> size3{1.5, -3.5};
+		saber::geometry::Size<double> expected3{1.0, -4.0};
 
 		auto roundSize1 = saber::geometry::RoundFloor(size1);
 		size1.RoundFloor();


### PR DESCRIPTION
Modified RoundNearest() to apropriately round values to nearest int