### PR TITLE
SABR-44: "`saber::HashValue<>` doesn't compile"

### DIFF
--- a/include/saber/hash.hpp
+++ b/include/saber/hash.hpp
@@ -44,8 +44,8 @@ namespace saber {
 /// everyone uses their own unique numbers.
 /// See: https://en.wikipedia.org/wiki/Hash_function
 ///
-/// NOTE: This is not a "secure hash". So, the result hash
-/// values are expected, but not gauranteed, to be: "unique".
+/// NOTE: Not a "secure hash"! So, the result hash values
+/// are expected, but not gauranteed, to be: "unique".
 /// Collisions can happen in rare circumstances. Beware!
 ///
 /// This class is "constexpr" so it's computed hash values
@@ -57,20 +57,41 @@ namespace saber {
 /// #include "saber/hash.hpp"
 /// main()
 /// {
-/// 	constexpr auto kMyConstant1 = saber::Hash{"my.component: Some String"};
-/// 	constexpr auto kMyConstant2 = saber::Hash{"some.service: Another String"};
-/// 	switch (Hash{})
+///		struct Color
+///		{
+///			unsigned char mRed{}, mGreen{} mBlue{};
+///		};
+///		constexpr Color kColor = {0x00, 0xff, 0x00};
+///
+///		// 1. Create using "string literal"
+/// 	constexpr auto kMyID_1 = saber::Hash{"my.component: Some locally unique string"};
+///		// 2. Create using L"string literal"
+/// 	constexpr auto kMyID_2 = saber::Hash{L"some.service: Another string"};
+///		// 3. Create using buffer + size
+/// 	constexpr auto kMyID_3 = saber::Hash{&kColor.mRed, sizeof(Color)};
+///
+///		constexpr auto kMyID = saber::Hash{"this.is.my.componenet"};
+/// 	switch (kMyID.Value())
 /// 	{
-/// 	case kMyConstant1:
-/// 	case kMyConstant2:
-/// 	default:
-/// 		break;
+///		// 1. Use with accessor
+/// 	case kMyID_1().Value:
+///			break;
+///		// 2. Use with operator ref()
+/// 	case kMyID_2():
+///			break;
+///		// 3. Use with static_cast<>()
+/// 	case static_cast<saber::Hash::ValueType>(kMyID_3):
+///			break;
 /// 	}
 ///
-/// 	enum class MyEnum : saber::Hash64::ValueType // underlying_type as Hash64::ValueType
+/// 	enum class MyEnum : saber::Hash::ValueType
 /// 	{
-/// 		// Beware: upcasting to enum loses `mKey` debug info in DEBUG builds
-/// 		kSomeEnum = saber::Hash64{"A descriptive string"};
+///			// 1. Use with accessor
+/// 		kSomeEnum1 = saber::Hash{"A unique string"}.Value();
+///			// 2. Use with operator ref()
+/// 		kSomeEnum2 = saber::Hash{"Second unique string"}();
+///			// 3. Use with static_cast<>()
+/// 		kSomeEnum3 = static_cast<saber::Hash::ValueType>(saber::Hash{"Third unique string"});
 /// 	};
 /// }
 /// @endcode
@@ -111,7 +132,7 @@ struct Fnv1aTraits<32> // Support for: 32bit hash
 		kOffset = 0x811c9dc5UL,
 		kPrime = 0x1000193UL
 	};
-};
+}; // struct Fnv1aTraits<32>
 
 /// @brief Specialization describing 64bit version of FNV1A
 template<>
@@ -124,7 +145,7 @@ struct Fnv1aTraits<64> // Support for: 64bit hash
 		kOffset = 0xcbf29ce484222325ULL,
 		kPrime = 0x100000001b3ULL
 	};
-};
+}; // struct Fnv1aTraits<64>
 
 /// @brief Functor that implements FNV1A has algorithm
 /// @tparam BitLength: Hash value size in bits
@@ -133,43 +154,43 @@ struct Fnv1a :
 	private Fnv1aTraits<BitLength> // is-impl-in-terms-of: Fnv1aTraits<>
 {
 public:
-	using typename Fnv1aTraits<BitLength>::ValueType; // Bring trait's ValueType into scope
+	using typename Fnv1aTraits<BitLength>::ValueType; // Bring trait's ValueType into public scope
 
-	// Functor ref() operator
+	// Functor "operator ref()"
 	template<typename T>
 	constexpr ValueType operator()(const T* inBuffer, std::size_t inSize) const noexcept
 	{
 		static_assert(std::is_integral_v<T>, "Only hashing of integral types are supported");
-		static_assert(sizeof(*inBuffer) <= 4, "Only hashing of integral types of: 8, 16, and 32 bit sizes are supported");
+		static_assert(sizeof(T) <= 4, "Only hashing of integral types of: 8, 16, and 32 bit sizes are supported");
 
-		ValueType basis = kOffset;
+		auto fnv1a = [](ValueType inBasis, unsigned char inByte)
+		{
+			const auto hash = Fnv1aTraits<BitLength>::kPrime
+								* (inBasis ^ static_cast<ValueType>(inByte));
+			return hash;
+		};
+
+		auto basis = Fnv1aTraits<BitLength>::kOffset;
 		for (std::size_t i = 0; i < inSize; i++)
 		{
 			const auto bytes = inBuffer[i];
-			switch (sizeof(*inBuffer)) // Support 8/16 *and* 32 bit variants of "T"
+			switch (sizeof(T)) // Support 8/16 *and* 32 bit variants of "T"
 			{
 			case 4: // 32bits
-				basis = Hash(basis, (bytes >> 24) & 0xff);
-				basis = Hash(basis, (bytes >> 16) & 0xff);
+				basis = fnv1a(basis, (bytes >> 24) & 0xff);
+			case 3: // ??
+				basis = fnv1a(basis, (bytes >> 16) & 0xff);
 			case 2: // 16bits
-				basis = Hash(basis, (bytes >> 8) & 0xff);
+				basis = fnv1a(basis, (bytes >> 8) & 0xff);
 			case 1: // 8bits
-				basis = Hash(basis, (bytes >> 0) & 0xff);
+				basis = fnv1a(basis, (bytes >> 0) & 0xff);
 				break;
 			default:
 				assert(!"Unsupported type. Only 8, 16, and 32 bit types are supported");
 				break;
-			}
+			} // switch (sizeof(T))
 		}
 		return basis;
-	}
-
-private:
-	// fnv1a hash algorithm
-	static constexpr ValueType Hash(ValueType inBasis, char inByte) noexcept
-	{
-		const auto hash = static_cast<ValueType>(kPrime * (inBasis ^ static_cast<ValueType>(inByte)));
-		return hash;
 	}
 }; // struct Fnv1a<>
 
@@ -178,18 +199,7 @@ private:
 #pragma endregion {}
 
 #if SABER_DEBUG
-namespace detail::debug {
-
-/// @brief Debug hint of source string "key" used to a generate result hash "value".
-///
-/// Only enabled in DEBUG builds, because it adds significant runtime
-/// overhead that's only useful when debugging.
-struct HashKey
-{
-	std::variant<std::string_view, std::wstring_view> mKey{}; // debug hint! for humans only!
-};
-
-} // namespace detail::debug
+namespace detail {
 #endif // SABER_DEBUG
 
 // ------------------------------------------------------------------
@@ -205,39 +215,23 @@ struct HashTraits
 {
 	using ImplType = detail::Fnv1a<BitLength>; // fnv1a!
 	using ValueType = typename ImplType::ValueType;
-};
+}; // struct HashTraits<>
 
-/// @brief Wraps the hashed value result of an input buffer.
-///
-/// By wrapping the hashed result in a class, we can also include
-/// as a debug-hint, a reference to the original input string.
-/// Note that this is a debug-hint for humans only, and appears
-/// only in debug builds.
+/// @brief Hashed value result of an input buffer.
 /// @tparam BitLength: Size of the hashed value in bits (typically 32 or 64)
 template<int BitLength>
 class HashValue :
-	public HashTraits<BitLength>::ValueType // is-a: hashed value type
+	private HashTraits<BitLength> // is-impl-in-terms-of: HashTraits<>
 {
 public:
-	using ValueType = typename HashTraits<BitLength>::ValueType;
+	using typename HashTraits<BitLength>::ValueType;
 
 public:
 	/// @brief Construct an empty `HashValue`
 	constexpr HashValue() noexcept :
-		HashTraits<BitLength>::ValueType{0}
+		mValue{0}
 	{
 		// This space intentionally blank
-	}
-
-	/// @brief Construct a `HashValue` from a 8bit string literal
-	/// @tparam N: Character count of the string literal (including 0x0 terminator)
-	/// @param inLiteral: Reference& to string literal to hash
-	template<int N>
-	constexpr HashValue(const char(&inLiteral)[N]) noexcept :
-		HashValue{std::string_view{inLiteral, N-1}} // N-1: exclude trailing '\0' from Hash
-	{
-		static_assert(N > 1, "HashValue(): inLiteral[] cannot be empty");
-		assert(inLiteral[N-1] == '\0' && "HashValue(): inLiteral[] must be '\0' terminated");
 	}
 
 	/// @brief Construct a `HashValue` from a 8bit string
@@ -245,20 +239,7 @@ public:
 	constexpr HashValue(std::string_view inString) noexcept :
 		HashValue{inString.data(), inString.size()}
 	{
-#if SABER_DEBUG
-		mDebug.mKey = inString;
-#endif // SABER_DEBUG
-	}
-
-	/// @brief Construct a `HashValue` from a 16bit wstring literal
-	/// @tparam N: Character count of the wstring literal (including 0x0 terminator)
-	/// @param inLiteral: Reference& to the wstring literal to hash
-	template<int N>
-	constexpr HashValue(const wchar_t(&inLiteral)[N]) noexcept :
-		HashValue{std::wstring_view{inLiteral, N-1}} // N-1: exclude trailing L'\0' from Hash
-	{
-		static_assert(N > 1, "HashValue(): inLiteral[] cannot be empty");
-		assert(inLiteral[N-1] == L'\0' && "HashValue(): inLiteral[] must be L'\0' terminated");
+		// This space intentionally blank
 	}
 
 	/// @brief Construct a `HashValue` from a 16bit string
@@ -266,9 +247,7 @@ public:
 	constexpr HashValue(std::wstring_view inString) noexcept :
 		HashValue{inString.data(), inString.size()}
 	{
-#if SABER_DEBUG
-		mDebug.mKey = inString;
-#endif // SABER_DEBUG
+		// This space intentionally blank
 	}
 
 	/// @brief Construct a `HashValue` from a buffer and element count
@@ -282,31 +261,126 @@ public:
 		// This space intentionally blank
 	}
 
+	/// @brief Return underlying `HashValue::ValueType`
+	/// @return Result hashed value
+	constexpr auto Value() const noexcept { return mValue; }
+
+	/// @brief "operator reference()" to `HashValue::ValueType`.
+	constexpr auto operator()() const noexcept { return Value(); }
+
+	/// @brief "operator cast" to `HashValue::ValueType`.
+	constexpr operator auto() const noexcept { return Value(); }
+
 private:
 	/// @brief Compute the hash of the provided buffer and element count
 	/// @tparam T: value type of the buffer
 	/// @param inBuffer: Pointer* to buffer to hash
 	/// @param inSize: Count of elements in buffer to hash
-	/// @return Hash value result
+	/// @return Hashed value result
 	template<typename T>
 	static constexpr ValueType Hash(const T* inBuffer, std::size_t inSize) noexcept
 	{
 		const ValueType value = sImpl(inBuffer, inSize);
-		assert(kNull != value && "HashValue(): hash collision with 0! Choose a different string");
+		assert(!!value && "HashValue(): hash collision with 0! Choose a different string");
 		return value;
 	}
 
 private:
 	using ImplType = typename HashTraits<BitLength>::ImplType;
-	static constexpr ImplType sImpl{}; // static fnv1a{} functor instance
-#if SABER_DEBUG
-	detail::debug::HashKey mDebug{};
-#endif // SABER_DEBUG
-}; // struct HashValue<>
+	static constexpr ImplType sImpl{}; // static hash-algoritm{} functor instance
+
+	ValueType mValue{};
+}; // class HashValue<>
 
 #pragma endregion {}
 
-using Hash = HashValue<8 * sizeof(std::size_t)>;
+#if SABER_DEBUG
+} // namespace detail
+#endif // SABER_DEBUG
+
+#if SABER_DEBUG
+// ------------------------------------------------------------------
+#pragma region struct debug::HashValue<>
+
+inline namespace debug { // "inline", meaning: also "using namespace debug;"
+
+/// @brief `debug::HashValue<>` hashed result of an input buffer.
+///
+/// During a debug build, this class extends the actual `HashValue<>`
+/// class to include as debug-hint: reference to original input key
+/// string. Note this key is a debug-hint for humans using a debugger,
+/// and is not available via any API.
+/// @tparam BitLength: Size of the hashed value in bits (typically 32 or 64)
+template<int BitLength>
+class HashValue :
+	public detail::HashValue<BitLength> // is-a: "the actual" HashValue<>
+{
+public:
+	using typename detail::HashValue<BitLength>::ValueType;
+
+public:
+	/// @brief Construct an empty `HashValue`
+	constexpr HashValue() noexcept :
+		detail::HashValue<BitLength>{},
+		mKey{"|empty|"}
+	{
+		// This space intentionally blank
+	}
+
+	/// @brief Construct a `HashValue` from a 8bit string
+	/// @param inString: View to string literal to hash
+	constexpr HashValue(std::string_view inString) noexcept :
+		detail::HashValue<BitLength>{inString},
+		mKey{inString}
+	{
+		// This space intentionally blank
+	}
+
+	/// @brief Construct a `HashValue` from a 16bit string
+	/// @param inString: View to wstring literal to hash
+	constexpr HashValue(std::wstring_view inString) noexcept :
+		detail::HashValue<BitLength>{inString},
+		mKey{inString}
+	{
+		// This space intentionally blank
+	}
+
+	/// @brief Construct a `HashValue` from a buffer and element count
+	/// @tparam T: value type of the buffer
+	/// @param inBuffer: Pointer* to buffer to hash
+	/// @param inSize: Count of elements in buffer to hash
+	template<typename T>
+	constexpr HashValue(const T* inBuffer, std::size_t inSize) noexcept :
+		detail::HashValue<BitLength>{inBuffer, inSize},
+		mKey{}
+	{
+		// This space intentionally blank
+	}
+
+	/// @brief Return underlying `HashValue::ValueType`
+	/// @return Result hashed value
+	constexpr auto Value() const noexcept { return detail::HashValue<BitLength>::Value(); }
+
+	/// @brief "operator reference()" to `HashValue::ValueType`.
+	constexpr auto operator()() const noexcept { return Value(); }
+
+	/// @brief "operator cast" to `HashValue::ValueType`.
+	constexpr operator auto() const noexcept { return Value(); }
+
+private:
+	/// @brief Debug hint: source string "key" used to generate result hashed "value".
+	///
+	/// Debug hint! For humans only! Enabled only in DEBUG builds, because it
+	/// adds significant runtime overhead that's only useful when debugging.
+	std::variant<std::string_view, std::wstring_view> mKey{};
+}; // class debug::HashValue<>
+
+} // namespace debug
+#endif // SABER_DEBUG
+
+#pragma endregion {}
+
+using Hash   = HashValue<8*sizeof(std::size_t)>;
 using Hash32 = HashValue<32>;
 using Hash64 = HashValue<64>;
 


### PR DESCRIPTION
Fix several issues in `saber::HashValue<>`:
- added debug layer to `HashValue<>`
- fix "dependent template base class" compile errors with `HashValueTraits<>`
- added accessor, operator ref&, plus `ValueType` cast operator
- spruced-up comments/documentation