### PR TITLE
SABR-43: "Where are the setters for `Point` and `Size`?"

### DIFF
--- a/include/saber/geometry/detail/impl2.hpp
+++ b/include/saber/geometry/detail/impl2.hpp
@@ -38,6 +38,13 @@ struct Impl2 final
             return std::get<Index>(mTuple);
         }
 
+        template<std::size_t Index>
+        constexpr void Set(T inT)
+        {
+            static_assert(Index < std::tuple_size_v<decltype(mTuple)>, "Provided index out of bounds.");
+            std::get<Index>(mTuple) = inT;
+        }
+
         constexpr Scalar& operator+=(const Scalar& inRHS)
         {
             std::get<0>(mTuple) += std::get<0>(inRHS.mTuple);
@@ -145,6 +152,13 @@ struct Impl2 final
         {
             static_assert(Index < std::tuple_size_v<decltype(mArray)>, "Provided index out of bounds.");
             return mArray[Index];
+        }
+
+        template<std::size_t Index>
+        constexpr void Set(T inT)
+        {
+            static_assert(Index < std::tuple_size_v<decltype(mArray)>, "Provided index out of bounds.");
+            mArray[Index] = inT;
         }
 
         constexpr auto GetSimdType() const

--- a/include/saber/geometry/detail/impl4.hpp
+++ b/include/saber/geometry/detail/impl4.hpp
@@ -45,6 +45,13 @@ struct Impl4 final
             return std::get<Index>(mTuple);
         }
 
+        template<std::size_t Index>
+        constexpr void Set(T inT)
+        {
+            static_assert(Index < std::tuple_size_v<decltype(mTuple)>, "Provided index out of bounds.");
+            std::get<Index>(mTuple) = inT;
+        }
+
         constexpr Scalar& operator+=(const Scalar& inRHS)
         {
             std::get<0>(mTuple) += std::get<0>(inRHS.mTuple);
@@ -179,6 +186,13 @@ struct Impl4 final
         {
             static_assert(Index < std::tuple_size_v<decltype(mArray)>, "Provided index out of bounds.");
             return mArray[Index];
+        }
+
+        template<std::size_t Index>
+        constexpr void Set(T inT)
+        {
+            static_assert(Index < std::tuple_size_v<decltype(mArray)>, "Provided index out of bounds.");
+            mArray[Index] = inT;
         }
 
         constexpr Simd& operator+=(const Simd& inRHS)

--- a/include/saber/geometry/point.hpp
+++ b/include/saber/geometry/point.hpp
@@ -38,8 +38,13 @@ public:
     constexpr Point(const Point& inCopy) = default;
     constexpr Point& operator=(const Point& inCopy) = default;
 
+    // Getters
     constexpr T X() const;
     constexpr T Y() const;
+
+    // Setters
+    constexpr void X(T inX);
+	constexpr void Y(T inY);
 
     // Mathematical operations
     constexpr Point& operator+=(const Point& inPoint);
@@ -107,6 +112,7 @@ inline constexpr Point<T, Impl>::Point(T inX, T inY) :
     // Do nothing
 }
 
+// Getters
 template<typename T, ImplKind Impl>
 inline constexpr T Point<T, Impl>::X() const
 {
@@ -117,6 +123,19 @@ template<typename T, ImplKind Impl>
 inline constexpr T Point<T, Impl>::Y() const
 {
     return mImpl.Get<1>();
+}
+
+// Setters
+template<typename T, ImplKind Impl>
+inline constexpr void Point<T, Impl>::X(T inX)
+{
+	mImpl.Set<0>(inX);
+}
+
+template<typename T, ImplKind Impl>
+inline constexpr void Point<T, Impl>::Y(T inY)
+{
+	mImpl.Set<1>(inY);
 }
 
 #pragma endregion

--- a/include/saber/geometry/size.hpp
+++ b/include/saber/geometry/size.hpp
@@ -38,8 +38,13 @@ public:
 	constexpr Size(const Size& inCopy) = default;
 	constexpr Size& operator=(const Size& inCopy) = default;
 
+	// Getters
 	constexpr T Width() const;
 	constexpr T Height() const;
+
+	// Setters
+	constexpr void Width(T inWidth);
+	constexpr void Height(T inHeight);
 
 	// Mathematical operations
 	constexpr Size& operator+=(const Size& inSize);
@@ -107,6 +112,7 @@ inline constexpr Size<T, Impl>::Size(T inWidth, T inHeight) :
 	// Do nothing
 }
 
+// Getters
 template<typename T, ImplKind Impl>
 inline constexpr T Size<T, Impl>::Width() const
 {
@@ -117,6 +123,19 @@ template<typename T, ImplKind Impl>
 inline constexpr T Size<T, Impl>::Height() const
 {
 	return mImpl.Get<1>();
+}
+
+// Setters
+template<typename T, ImplKind Impl>
+inline constexpr void Size<T, Impl>::Width(T inWidth)
+{
+	mImpl.Set<0>(inWidth);
+}
+
+template<typename T, ImplKind Impl>
+inline constexpr void Size<T, Impl>::Height(T inHeight)
+{
+	mImpl.Set<1>(inHeight);
 }
 
 #pragma endregion

--- a/test/geometry_unittest.cpp
+++ b/test/geometry_unittest.cpp
@@ -118,6 +118,16 @@ TEMPLATE_TEST_CASE(	"saber::geometry::Point::ctor() works correctly",
 		REQUIRE(Scale<TestType>(Point<TestType>{5,3}, 2,4) == Point<TestType>{10,12});
 		REQUIRE(Scale<TestType>(Point<TestType>{6,7}, 2) == Point<TestType>{12,14});
 	}
+
+	SECTION("Setters")
+	{
+		auto x = Point<TestType>{2,3};
+		x.X(3);
+		REQUIRE(x == Point<TestType>{3,3});
+		auto y = Point<TestType>{2,3};
+		y.Y(2);
+		REQUIRE(y == Point<TestType>{2,2});
+	}
 }
 
 TEMPLATE_TEST_CASE(	"saber::geometry::Size::ctor() works correctly",
@@ -206,6 +216,16 @@ TEMPLATE_TEST_CASE(	"saber::geometry::Size::ctor() works correctly",
 		REQUIRE(Scale<TestType>(Size<TestType>{2,3}, Size<TestType>{4,3}) == Size<TestType>{8,9});
 		REQUIRE(Scale<TestType>(Size<TestType>{5,3}, 2,4) == Size<TestType>{10,12});
 		REQUIRE(Scale<TestType>(Size<TestType>{6,7}, 2) == Size<TestType>{12,14});
+	}
+
+	SECTION("Setters")
+	{
+		auto width = Size<TestType>{2,3};
+		width.Width(3);
+		REQUIRE(width == Size<TestType>{3,3});
+		auto height = Size<TestType>{2,3};
+		height.Height(2);
+		REQUIRE(height == Size<TestType>{2,2});
 	}
 }
 
@@ -565,6 +585,19 @@ TEMPLATE_TEST_CASE(	"saber::geometry::Rectangle::ctor() works correctly",
 		REQUIRE(Rectangle<TestType>{2,3,2,3}.Scale(Size<TestType>{4,3}) == Rectangle<TestType>{8,9,8,9});
 		REQUIRE(Rectangle<TestType>{5,3,5,3}.Scale(2,4) == Rectangle<TestType>{10,12,10,12});
 		REQUIRE(Rectangle<TestType>{6,7,6,7}.Scale(2) == Rectangle<TestType>{12,14,12,14});
+	}
+
+	SECTION("Setters")
+	{
+		auto rectangle = Rectangle<TestType>{0,0,0,0};
+		rectangle.X(1);
+		REQUIRE(rectangle == Rectangle<TestType>{1,0,0,0});
+		rectangle.Y(2);
+		REQUIRE(rectangle == Rectangle<TestType>{1,2,0,0});
+		rectangle.Width(3);
+		REQUIRE(rectangle == Rectangle<TestType>{1,2,3,0});
+		rectangle.Height(4);
+		REQUIRE(rectangle == Rectangle<TestType>{1,2,3,4});
 	}
 }
 


### PR DESCRIPTION
Added setters to all geometry and impl classes