### PR TITLE
SABR-47: "SABER_BUILD_DOCS doesn't work anymore"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,8 +50,7 @@
                 "args": [], 
                 "cwd": "${workspaceFolder}/build/test/Debug", // Change this to the directory of your executable
                 "MIMode": "gdb"
-            },
-            
+            }, 
             //"args": [], // No Args
             //"cwd": "${workspaceFolder}/lib/win-x64", // Change this to the directory of your executable
             "stopAtEntry": true, // Set to true to stop program execution at the first line of code

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,5 @@
 {
 	"cmake.loggingLevel": "trace",
-	"cmake.sourceDirectory": "${workspaceFolder}/.",
-	"cmake.configureSettings": {
-		"CMAKE_BUILD_TYPE": "${buildType}",
-		"SABER_BUILD_UNITTESTS": true,
-		"SABER_BUILD_BENCHMARKS": true,
-		"SABER_BUILD_DOCS": false,
-	},
 	"files.associations": {
 		"stdexcept": "cpp",
 		"xstring": "cpp",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,34 +9,45 @@
 				// will get the error "make failed with code 2."
 				"cwd": "${workspaceFolder}",
 		},
+
 	"tasks": [
 		{
 			"label": "build",
 			"type": "shell",
-			"command": "cmake --build ./build",
+			"windows": {
+				"command": "cmake --build --preset win"
+			},
+			"osx": {
+				"command": "cmake --build --preset mac"
+			},
+			"linux": {
+				"command": "cmake --build --preset linux-debug"
+			},
 			"group": {
 				"kind": "build",
 				"isDefault": true
 			},
 			"problemMatcher": []
 		},
+
 		{
 			"label": "regenerate/build",
 			"type": "shell",
 			"windows": {
-				"command": "cmake -G \"Visual Studio 17 2022\" -S . -B ./build && cmake --build ./build"
+				"command": "cmake --preset win && cmake --build --preset win"
 			},
 			"osx": {
-				"command": "cmake -G \"Xcode\" -DIOS=OFF -DCMAKE_SYSTEM_NAME=Darwin -S . -B ./build && cmake --build ./build"
+				"command": "cmake --preset mac && cmake --build --preset mac"
 			},
 			"linux": {
-				"command": "cmake -G \"Unix Makefiles\" -S . -B ./build && cmake --build ./build"
+				"command": "cmake --preset linux-debug && cmake --build --preset linux-debug"
 			},
 			"group": {
 				"kind": "build",
 				"isDefault": false
 			}
 		},
+
 		{
 			"label": "regenerate/build iOS",
 			"type": "shell",
@@ -44,7 +55,7 @@
 				"command": "echo \"iOS builds not supported on Windows!\""
 			},
 			"osx": {
-				"command": "cmake -G \"Xcode\" -DIOS=ON -DCMAKE_SYSTEM_NAME=Darwin -S . -B ./build && cmake --build ./build"
+				"command": "cmake --preset ios && cmake --build --preset ios"
 			},
 			"linux": {
 				"command": "echo \"iOS builds not supported on Linux!\""
@@ -54,19 +65,29 @@
 				"isDefault": false
 			}
 		},
+
 		{
 			"label": "clean",
 			"type": "shell",
-			"command": "cmake --build ./build --target clean",
+			"windows": {
+				"command": "cmake --build --preset win --target clean"
+			},
+			"osx": {
+				"command": "cmake --build --preset mac --target clean && cmake --build --preset ios --target clean"
+			},
+			"linux": {
+				"command": "cmake --build --preset linux-debug --target clean"
+			},
 			"group": {
 				"kind": "build",
 				"isDefault": false
 			}
 		},
+
 		{
 			"label": "test",
 			"type": "shell",
-			"command": "(cd ./build && ctest -C Debug --verbose)",
+			"command": "(cd ${workspaceFolder}/build && ctest -C Debug --verbose)",
 			"group": {
 				"kind": "test",
 				"isDefault": true

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,158 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+
+  "configurePresets": [
+    {
+      "name": "win",
+      "displayName": "Windows",
+      "description": "Build for Windows using Visual Studio",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "SABER_BUILD_UNITTESTS": "ON",
+        "SABER_BUILD_BENCHMARKS": "ON",
+        "SABER_BUILD_DOCS": "OFF",
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+
+    {
+      "name": "mac",
+      "displayName": "macOS",
+      "description": "Build for macOS using Xcode",
+      "generator": "Xcode",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "SABER_BUILD_UNITTESTS": "ON",
+        "SABER_BUILD_BENCHMARKS": "ON",
+        "SABER_BUILD_DOCS": "OFF",
+        "CMAKE_BUILD_TYPE": "Debug",
+		"IOS": "OFF"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+
+	{
+      "name": "ios",
+      "displayName": "iOS",
+      "description": "Build for iOS using Xcode",
+      "generator": "Xcode",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "SABER_BUILD_UNITTESTS": "ON",
+        "SABER_BUILD_BENCHMARKS": "ON",
+        "SABER_BUILD_DOCS": "OFF",
+        "CMAKE_BUILD_TYPE": "Debug",
+		"IOS": "ON"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+
+    {
+      "name": "linux-debug",
+      "displayName": "Linux Debug",
+      "description": "Debug build for Linux using Make",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "SABER_BUILD_UNITTESTS": "ON",
+        "SABER_BUILD_BENCHMARKS": "ON",
+        "SABER_BUILD_DOCS": "OFF",
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+
+    {
+      "name": "linux-release",
+      "displayName": "Linux Release",
+      "description": "Release build for Linux using Make",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "SABER_BUILD_UNITTESTS": "ON",
+        "SABER_BUILD_BENCHMARKS": "ON",
+        "SABER_BUILD_DOCS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+
+    {
+      "name": "linux-relwithdebinfo",
+      "displayName": "Linux RelWithDebInfo",
+      "description": "RelWithDebInfo build for Linux using Make",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "SABER_BUILD_UNITTESTS": "ON",
+        "SABER_BUILD_BENCHMARKS": "ON",
+        "SABER_BUILD_DOCS": "OFF",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    }
+  ],
+
+  "buildPresets": [
+    {
+      "name": "win",
+      "configurePreset": "win"
+    },
+
+    {
+      "name": "mac",
+      "configurePreset": "mac"
+    },
+
+    {
+      "name": "ios",
+      "configurePreset": "ios"
+    },
+
+    {
+      "name": "linux-debug",
+      "configurePreset": "linux-debug"
+    },
+
+    {
+      "name": "linux-release",
+      "configurePreset": "linux-release"
+    },
+
+    {
+      "name": "linux-relwithdebinfo",
+      "configurePreset": "linux-relwithdebinfo"
+    }
+  ]
+}

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -22,13 +22,16 @@ if(SABER_BUILD_DOCS)
 	# This allows us to get the path to doxygen-awesome.css
 	FetchContent_GetProperties(doxygen-awesome-css SOURCE_DIR DOXYGEN_AWESOME_DIR)
 
-	find_package(Doxygen)
-	if(NOT DOXYGEN_FOUND)
-		message(SEND_ERROR	"Doxygen not found. The 'docs' target is not available. "
-							"To generate documentation, you must install Doxygen, "
-							"ensure that it's available in your $PATH, and re-run CMake.")
+	# Build the docset requires previously installed tools:
+	# "Doxygen" and "Graphviz"
+	find_package(Doxygen REQUIRED dot) # "dot", meaning: Weird name given to Graphviz tool by Graphviz.org
+	if(NOT(Doxygen_FOUND AND Doxygen_dot_FOUND))
+		message(SEND_ERROR
+			"Doxygen and Graphviz not found. The 'docs' target is not available. "
+			"To generate documentation, you must install Doxygen, and Graphviz and "
+			"ensure that it's available in your $PATH, and re-run CMake.")
 		return()
-	endif() # NOT DOXYGEN_FOUND
+	endif()
 
 	set(DOXYGEN_OUTPUT_DIR ${PROJECT_BINARY_DIR}/doc/webdocs)
 	# Clean and rebuild output dir...


### PR DESCRIPTION
Mostly "operator error (my fault)"... because to produce doxygen webdocs output you must:
1. "cmake configure" `-DSABER_BUILD_DOCS=ON`
2. _and then_ "cmake --build". This will produce docs at: `./build/webdocs/index.html`

In my case, I forgot step (2)... So no webdoc output was created.
However, while the hood was up, I fixed these things:
- Added  a check for "doxygen is-installed" during build phse
- Moved nitty-gritty cmake command line args from `./vscode/*.json` files to a proper `CMakePresets.json` file