### PR TITLE
SABR-73: "CMakelists.txt gives wrong error msg during vs2026 config"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 4.2) # at least vs2026 support
 
 project(
 	saber

--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ There are 3 `saber` build targets, dis/enabled via macro defines:
 CMakePresets.json provides presets for building
 these targets on a variety of supported platforms.
 These are the available presets for configuring (regenerate) project/make files from cmake:
-* `config-win-{vs2022|vs2026} -- -A {x64|arm64}`
+* `config-win-{vs2022|vs2026} -A {x64|arm64}`
 * `config-{macos|ios}-xcode`
-* `config-linux-make -- -A {x64|arm64} -DCMAKE_BUILD_TYPE={Debug|Release|RelWithDebInfo|MinSizeRel}`
+* `config-linux-make -A {x64|arm64} -DCMAKE_BUILD_TYPE={Debug|Release|RelWithDebInfo|MinSizeRel}`
 ```
-> cmake --preset config-win-vs2022 -- -A x64
+> cmake --preset config-win-vs2022 -A x64
 ```
 Presets available for building projects directly from cmake:
-* `build-win-{vs2022|vs2026} -- -A {x64|arm64} --config {Debug|Release|RelWithDebInfo|MinSizeRel}`
-* `build-[macos|ios]-xcode -- -config {Debug|Release|RelWithDebInfo|MinSizeRel}`
+* `build-win-{vs2022|vs2026} -A {x64|arm64} --config {Debug|Release|RelWithDebInfo|MinSizeRel}`
+* `build-[macos|ios]-xcode -config {Debug|Release|RelWithDebInfo|MinSizeRel}`
 * `build-ios-{Debug|Release|RelWithDebInfo|MinSizeRel}`
-* `build-linux-make -- -A {x64|arm64} --config {Debug|Release|RelWithDebInfo|MinSizeRel}`
+* `build-linux-make -A {x64|arm64} --config {Debug|Release|RelWithDebInfo|MinSizeRel}`
 ```
-> cmake --build --preset build-win-vs2022 -- -A x64 --config Debug
+> cmake --build --preset build-win-vs2022 -A x64 --config Debug
 ```
 
 Note: The cmake generators 'Visual Studio 17 2022' and 'Xcode'


### PR DESCRIPTION
Fixed two things:
1. update cmake min vers requirement
2. documentation cleanup