### PR TITLE
SABR-81: "Update saber_benchmarks to test geometry classes"

### DIFF
--- a/cmake/cxxflags_common.cmake
+++ b/cmake/cxxflags_common.cmake
@@ -25,8 +25,8 @@ if (MSVC)
 	# revert to the desired (and default) inlining behavior as that exercises more interesting code paths
 	if ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 		# TODO: This is currently blocked by an apparent Clang bug: https://github.com/llvm/llvm-project/issues/59690
-		# replace_cxx_flag("/Ob1" "/Ob2")
-		replace_cxx_flag("/Ob1" "/Ob2")
+		# replace_cxx_flag("/Ob1" "/Ob3")
+		replace_cxx_flag("/Ob1" "/Ob3")
 	endif() # STREQUAL "RelWithDebInfo"
 
 	# Turn on "multi-procssor compilation" switch

--- a/include/saber/geometry/operators.hpp
+++ b/include/saber/geometry/operators.hpp
@@ -5,17 +5,83 @@
 #include <type_traits>
 
 namespace saber::geometry {
+namespace detail {
+
+// TRICKY j3fitz 08apr2026: Generic set of operators +, -, *, /, for geometry types...
+// that also avoids the dreaded "error C2593: 'operator +' is ambiguous" compile error.
+//
+// The problem here is a "template" free function operator accepting a generic type "T".
+// Using "T" allows us (good) to have single template operator impls for all our geometry
+// types: (Point/Size/Rectangle/Matrix), rather than copy/paste for each type.
+// However, "other types" can get sucked-into/match generic type "T", (bad) which don't
+// make sense for our operators (like: int, or std::string). This confuses the compiler
+// and results in dreaded compile error: "error C2593: 'operator +' is ambiguous"...
+// as the compiler doesn't know whether "+" between two ints means: use regular addition,
+// or use our custom "+" operator. Yuck!
+//
+// The solution is twofold:
+// 1. define the operators in "same namespace" as the target types:
+//    so ADL (Arg Dependent Lookup) will find/match an operator only when arguments
+//    passed to operator are also in same namespace
+// 2. use SFINAE to prevent unrelated types from being considered as candidates
+//    for our operators
+//
+// We do this with a custom `is_geometry_compatible` trait, specialized for our
+// geometry types, that is used to selectively SFINAE-enable our operators
+
+template<typename T>
+struct is_geometry_compatible : std::false_type {}; // by default: `false`
+
+template<typename T>
+constexpr bool is_geometry_compatible_v = is_geometry_compatible<T>::value;
+
+} // namespace detail
+
+// Forward declare the geometry types we want to use for our operators
+template<typename T, ImplKind Impl>
+class Point;
+
+template<typename T, ImplKind Impl>
+class Size;
+
+template<typename T, ImplKind Impl>
+class Rectangle;
+
+template<typename T, ImplKind Impl>
+class Matrix;
+
+// Opt-in the geometry types for operator support by specializing `is_geometry_compatible` trait
+template<typename T>
+struct detail::is_geometry_compatible<Point<T, ImplKind::kScalar>> : std::true_type {};
+template<typename T>
+struct detail::is_geometry_compatible<Point<T, ImplKind::kSimd>> : std::true_type {};
+
+template<typename T>
+struct detail::is_geometry_compatible<Size<T, ImplKind::kScalar>> : std::true_type {};
+template<typename T>
+struct detail::is_geometry_compatible<Size<T, ImplKind::kSimd>> : std::true_type {};
+
+template<typename T>
+struct detail::is_geometry_compatible<Rectangle<T, ImplKind::kScalar>> : std::true_type {};
+template<typename T>
+struct detail::is_geometry_compatible<Rectangle<T, ImplKind::kSimd>> : std::true_type {};
+
+template<typename T>
+struct detail::is_geometry_compatible<Matrix<T, ImplKind::kScalar>> : std::true_type {};
+template<typename T>
+struct detail::is_geometry_compatible<Matrix<T, ImplKind::kSimd>> : std::true_type {};
 
 /// @brief Binary Operator that adds 2 input types returning a result of the same type
-/// Use it like this: 
+/// Use it like this:
 /// ```
 /// auto result = type1 + type2;
 /// ```
 /// @tparam T underlying type
+/// @tparam SFINAE enable this operator+() only for saber::geometry types
 /// @param inLHS: Left hand side argument
-/// @param inRHS: Right hand side argument 
+/// @param inRHS: Right hand side argument
 /// @return Sum result
-template<typename T>
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
 inline constexpr T operator+(const T& inLHS, const T& inRHS)
 {
     // Incomprehensible c++ incantation to detect if T implements operator+=()
@@ -28,15 +94,16 @@ inline constexpr T operator+(const T& inLHS, const T& inRHS)
 }
 
 /// @brief Binary Operator that subtracts 2 input types returning a result of the same type
-/// Use it like this: 
+/// Use it like this:
 /// ```
 /// auto result = type1 - type2;
 /// ```
 /// @tparam T underlying type
+/// @tparam SFINAE enable this operator-() only for saber::geometry types
 /// @param inLHS: Left hand side argument
-/// @param inRHS: Right hand side argument 
+/// @param inRHS: Right hand side argument
 /// @return Difference result
-template<typename T>
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
 inline constexpr T operator-(const T& inLHS, const T& inRHS)
 {
     // Incomprehensible c++ incantation to detect if T implements operator-=()
@@ -49,15 +116,16 @@ inline constexpr T operator-(const T& inLHS, const T& inRHS)
 }
 
 /// @brief Binary Operator that multiplies 2 input types returning a result of the same type
-/// Use it like this: 
+/// Use it like this:
 /// ```
 /// auto result = type1 * type2;
 /// ```
 /// @tparam T underlying type
+/// @tparam SFINAE enable this operator*() only for saber::geometry types
 /// @param inLHS: Left hand side argument
-/// @param inRHS: Right hand side argument 
+/// @param inRHS: Right hand side argument
 /// @return Product result
-template<typename T>
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
 inline constexpr T operator*(const T& inLHS, const T& inRHS)
 {
     // Incomprehensible c++ incantation to detect if T implements operator*=()
@@ -70,15 +138,16 @@ inline constexpr T operator*(const T& inLHS, const T& inRHS)
 }
 
 /// @brief Binary Operator that divides 2 input types returning a result of the same type
-/// Use it like this: 
+/// Use it like this:
 /// ```
 /// auto result = type1 / type2;
 /// ```
 /// @tparam T underlying type
+/// @tparam SFINAE enable this operator/() only for saber::geometry types
 /// @param inLHS: Left hand side argument
-/// @param inRHS: Right hand side argument 
+/// @param inRHS: Right hand side argument
 /// @return Quotient result
-template<typename T>
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
 inline constexpr T operator/(const T& inLHS, const T& inRHS)
 {
     // Incomprehensible c++ incantation to detect if T implements operator/=()
@@ -90,7 +159,17 @@ inline constexpr T operator/(const T& inLHS, const T& inRHS)
     return result;
 }
 
-template<typename T>
+/// @brief Binary Operator that compares 2 input values for equality returning a bool result
+/// Use it like this:
+/// ```
+/// auto result = value1 == values2;
+/// ```
+/// @tparam T underlying type
+/// @tparam SFINAE enable this operator==() only for saber::geometry types
+/// @param inLHS: Left hand side argument
+/// @param inRHS: Right hand side argument
+/// @return Quotient result
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
 inline constexpr bool operator==(const T& inLHS, const T& inRHS)
 {
     // Incomprehensible c++ incantation to detect if T implements IsEqual()
@@ -101,7 +180,7 @@ inline constexpr bool operator==(const T& inLHS, const T& inRHS)
     return result;
 }
 
-template<typename T>
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
 inline constexpr bool operator!=(const T& inLHS, const T& inRHS)
 {
     // Incomprehensible c++ incantation to detect if T implements IsEqual()
@@ -114,14 +193,14 @@ inline constexpr bool operator!=(const T& inLHS, const T& inRHS)
 
 // Unary Operators
 
-template<typename T>
-inline constexpr T operator-(const T& inLHS) // Unary negation, not subtraction
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
+inline constexpr T operator-(const T& inLHS) // Unary negation (e.g: not subtraction)
 { 
     const T zero{};
     return zero - inLHS;
 }
 
-template<typename T>
+template<typename T, typename SFINAE = std::enable_if_t<detail::is_geometry_compatible_v<T>>>
 inline constexpr T operator+(const T& inLHS) // Unary addition = noOp
 {
     return inLHS; // copy

--- a/include/saber/geometry/rectangle.hpp
+++ b/include/saber/geometry/rectangle.hpp
@@ -7,7 +7,7 @@
 #include "saber/geometry/point.hpp"
 #include "saber/geometry/size.hpp"
 #include "saber/geometry/detail/impl4.hpp"
-#include "saber/utility.hpp"
+#include "saber/geometry/utility.hpp"
 
 // std
 #include <utility>

--- a/include/saber/inexact.hpp
+++ b/include/saber/inexact.hpp
@@ -53,24 +53,35 @@ public:
     struct Eq
     {
     public:
-        Eq(const T& inLHS) :
-            mLHS{inLHS}
+        Eq(const T& inLHS) : mLHS{ inLHS } {}
+
+        template<typename U = T, typename SFINAE = std::enable_if_t<std::is_integral_v<U>>>
+        bool operator()(const T& inRHS) const
         {
-            constexpr bool isFloatingPoint = std::is_floating_point_v<T>;
-            static_assert(isFloatingPoint, "Eq only supports floating point types");
-        };
+            return (mLHS == inRHS); // integral types can be compared using regular equality
+        }
 
         bool operator()(const T& inRHS) const
         {
-            // magnitude: the further we get away from 0, the more inexactness we allow
-            const T magnitude = std::max<T>(std::max<T>(std::abs(mLHS), std::abs(inRHS)), 1.0f); 
-            // difference: compare the 2 numbers
-            const T difference = std::abs(mLHS - inRHS);
-            // epsilon: minimal permitted amount of inexactness
-            const T epsilon = std::numeric_limits<T>::epsilon() * magnitude;
-            // IsEqual: equality occurs if the difference is within a scaled epsilon
-            const bool IsEqual = difference <= epsilon; // some arbirtary small number (Note: Intergral epsilon is 0)
-            return IsEqual;
+            if constexpr (!std::is_floating_point_v<T>)
+            {
+                // integral types can be compared using regular equality
+                return (mLHS == inRHS);
+            }
+            else
+            {
+                // floating point types require finesse to account for "inexactness"...
+
+                // magnitude: the further we get away from 0, the more inexactness we allow
+                const T magnitude = std::max<T>(std::max<T>(std::abs(mLHS), std::abs(inRHS)), 1.0f);
+                // difference: compare the 2 numbers
+                const T difference = std::abs(mLHS - inRHS);
+                // epsilon: minimal permitted amount of inexactness
+                const T epsilon = std::numeric_limits<T>::epsilon() * magnitude;
+                // IsEqual: equality occurs if the difference is within a scaled epsilon
+                const bool IsEqual = difference <= epsilon; // some arbirtary small number (Note: Intergral epsilon is 0)
+                return IsEqual;
+            }
         }
 
     private:
@@ -84,12 +95,7 @@ public:
     struct Ne
     {
     public:
-        Ne(const T& inLHS) :
-            mLHS{inLHS}
-        {
-            constexpr bool isFloatingPoint = std::is_floating_point_v<T>;
-            static_assert(isFloatingPoint, "Ne only supports floating point types");
-        };
+        Ne(const T& inLHS) : mLHS{inLHS} {}
 
         bool operator()(const T& inRHS) const
         {

--- a/test/geometry_benchmark.cpp
+++ b/test/geometry_benchmark.cpp
@@ -23,432 +23,996 @@
 /////////////////////////////////////////////////////////////////////
 
 // catch2
-#include "catch2/catch_test_macros.hpp"
 #include <catch2/benchmark/catch_benchmark.hpp>
+#include "catch2/catch_template_test_macros.hpp"
 
 // saber
 #include "saber/geometry/point.hpp"
 #include "saber/geometry/size.hpp"
+#include "saber/geometry/rectangle.hpp"
+#include "saber/geometry/matrix.hpp"
 
 // std
 #include <array>
 #include <ctime>
 #include <iostream>
 #include <string>
-#include <tuple>
-#include <vector>
 
-saber::geometry::Point<float> sFloatPoint{};
-saber::geometry::Point<double> sDoublePoint{};
-saber::geometry::Point<int> sIntPoint{};
-
-TEST_CASE("saber::geometry::Point", "[saber]")
+template<typename T>
+constexpr const char* TypeName()
 {
-	int gauranteedNotConstexpr = 0;
-	{
-		// TRICKY j3fitz 30nov2024: Prevent compiler from optimizing away all benchmark work.
-		// By using a value in the benchmark computation that can't be known at
-		// compile-time, we force the compiler to emit code to perform computation at
-		// runtime. Otherwise, the compiler is smart enuf to do the math at compile-time
-		// and just emit a final answer at runtime... defeating the purpose of the benchmark!
-
-		// Get current time: "unknowable at compile-time"
-		std::time_t t = std::time(nullptr);
-		std::tm* now = std::localtime(&t);
-		const auto dayOfWeek = now->tm_wday;
-		gauranteedNotConstexpr = dayOfWeek+1; // +1: -> [1...7]
-	}
-
-	saber::geometry::Point<float> floatPoint1{static_cast<float>(gauranteedNotConstexpr), -static_cast<float>(gauranteedNotConstexpr)};
-	saber::geometry::Point<float> floatPoint2{2.0f, -3.0f};
-
-	BENCHMARK("saber::geometry::Point<float> operator+")
-	{
-		auto floatPoint = floatPoint1 + floatPoint2;
-		floatPoint += floatPoint + floatPoint1;
-		floatPoint += floatPoint + floatPoint2;
-		floatPoint += floatPoint + floatPoint1;
-		floatPoint += floatPoint + floatPoint2;
-		floatPoint += floatPoint + floatPoint1;
-		floatPoint += floatPoint + floatPoint2;
-		floatPoint += floatPoint + floatPoint1;
-		floatPoint += floatPoint + floatPoint2;
-		sFloatPoint += floatPoint;
-	};
-
-	BENCHMARK("saber::geometry::Point<float> operator-")
-	{
-		auto floatPoint = floatPoint1 - floatPoint2;
-		floatPoint -= floatPoint - floatPoint1;
-		floatPoint -= floatPoint - floatPoint2;
-		floatPoint -= floatPoint - floatPoint1;
-		floatPoint -= floatPoint - floatPoint2;
-		floatPoint -= floatPoint - floatPoint1;
-		floatPoint -= floatPoint - floatPoint2;
-		floatPoint -= floatPoint - floatPoint1;
-		floatPoint -= floatPoint - floatPoint2;
-		sFloatPoint -= floatPoint;
-	};
-
-	BENCHMARK("saber::geometry::Point<float> operator*")
-	{
-		auto floatPoint = floatPoint1 * floatPoint2;
-		floatPoint *= floatPoint * floatPoint1;
-		floatPoint *= floatPoint * floatPoint2;
-		floatPoint *= floatPoint * floatPoint1;
-		floatPoint *= floatPoint * floatPoint2;
-		floatPoint *= floatPoint * floatPoint1;
-		floatPoint *= floatPoint * floatPoint2;
-		floatPoint *= floatPoint * floatPoint1;
-		floatPoint *= floatPoint * floatPoint2;
-		sFloatPoint *= floatPoint;
-	};
-
-	floatPoint1 = {1.0f, static_cast<float>(gauranteedNotConstexpr/gauranteedNotConstexpr)};
-	floatPoint2 = {1.0f, -1.0f};
-	BENCHMARK("saber::geometry::Point<float> operator/")
-	{
-		auto floatPoint = floatPoint1 / floatPoint2;
-		floatPoint /= floatPoint / floatPoint1;
-		floatPoint /= floatPoint / floatPoint2;
-		floatPoint /= floatPoint / floatPoint1;
-		floatPoint /= floatPoint / floatPoint2;
-		floatPoint /= floatPoint / floatPoint1;
-		floatPoint /= floatPoint / floatPoint2;
-		floatPoint /= floatPoint / floatPoint1;
-		floatPoint /= floatPoint / floatPoint2;
-		sFloatPoint /= floatPoint;
-	};
-
-	saber::geometry::Point<double> doublePoint1{ static_cast<double>(gauranteedNotConstexpr), -static_cast<double>(gauranteedNotConstexpr)};
-	saber::geometry::Point<double> doublePoint2{2.0, -3.0};
-
-	saber::geometry::Point<double> doublePoint3{};
-	BENCHMARK("saber::geometry::Point<double> operator+")
-	{
-		auto doublePoint = doublePoint1 + doublePoint2;
-		doublePoint += doublePoint + doublePoint1;
-		doublePoint += doublePoint + doublePoint2;
-		doublePoint += doublePoint + doublePoint1;
-		doublePoint += doublePoint + doublePoint2;
-		doublePoint += doublePoint + doublePoint1;
-		doublePoint += doublePoint + doublePoint2;
-		doublePoint += doublePoint + doublePoint1;
-		doublePoint += doublePoint + doublePoint2;
-		sDoublePoint += doublePoint;
-	};
-
-	BENCHMARK("saber::geometry::Point<double> operator-")
-	{
-		auto doublePoint = doublePoint1 - doublePoint2;
-		doublePoint -= doublePoint - doublePoint1;
-		doublePoint -= doublePoint - doublePoint2;
-		doublePoint -= doublePoint - doublePoint1;
-		doublePoint -= doublePoint - doublePoint2;
-		doublePoint -= doublePoint - doublePoint1;
-		doublePoint -= doublePoint - doublePoint2;
-		doublePoint -= doublePoint - doublePoint1;
-		doublePoint -= doublePoint - doublePoint2;
-		sDoublePoint -= doublePoint;
-	};
-
-	BENCHMARK("saber::geometry::Point<double> operator*")
-	{
-		auto doublePoint = doublePoint1 * doublePoint2;
-		doublePoint *= doublePoint * doublePoint1;
-		doublePoint *= doublePoint * doublePoint2;
-		doublePoint *= doublePoint * doublePoint1;
-		doublePoint *= doublePoint * doublePoint2;
-		doublePoint *= doublePoint * doublePoint1;
-		doublePoint *= doublePoint * doublePoint2;
-		doublePoint *= doublePoint * doublePoint1;
-		doublePoint *= doublePoint * doublePoint2;
-		sDoublePoint *= doublePoint;
-	};
-
-	doublePoint1 = {1.0, static_cast<double>(gauranteedNotConstexpr/gauranteedNotConstexpr)};
-	doublePoint2 = {1.0, -1.0};
-	BENCHMARK("saber::geometry::Point<double> operator/")
-	{
-		auto doublePoint = doublePoint1 / doublePoint2;
-		doublePoint /= doublePoint / doublePoint1;
-		doublePoint /= doublePoint / doublePoint2;
-		doublePoint /= doublePoint / doublePoint1;
-		doublePoint /= doublePoint / doublePoint2;
-		doublePoint /= doublePoint / doublePoint1;
-		doublePoint /= doublePoint / doublePoint2;
-		doublePoint /= doublePoint / doublePoint1;
-		doublePoint /= doublePoint / doublePoint2;
-		sDoublePoint /= doublePoint;
-	};
-
-	saber::geometry::Point<int> intPoint1{static_cast<int>(gauranteedNotConstexpr), -static_cast<int>(gauranteedNotConstexpr)};
-	saber::geometry::Point<int> intPoint2{2, -3};
-
-	saber::geometry::Point<int> intPoint3{};
-	BENCHMARK("saber::geometry::Point<int> operator+")
-	{
-		auto intPoint = intPoint1 + intPoint2;
-		intPoint += intPoint + intPoint1;
-		intPoint += intPoint + intPoint2;
-		intPoint += intPoint + intPoint1;
-		intPoint += intPoint + intPoint2;
-		intPoint += intPoint + intPoint1;
-		intPoint += intPoint + intPoint2;
-		intPoint += intPoint + intPoint1;
-		intPoint += intPoint + intPoint2;
-		sIntPoint += intPoint;
-	};
-
-	BENCHMARK("saber::geometry::Point<int> operator-")
-	{
-		auto intPoint = intPoint1 - intPoint2;
-		intPoint -= intPoint - intPoint1;
-		intPoint -= intPoint - intPoint2;
-		intPoint -= intPoint - intPoint1;
-		intPoint -= intPoint - intPoint2;
-		intPoint -= intPoint - intPoint1;
-		intPoint -= intPoint - intPoint2;
-		intPoint -= intPoint - intPoint1;
-		intPoint -= intPoint - intPoint2;
-		sIntPoint -= intPoint;
-	};
-
-	BENCHMARK("saber::geometry::Point<int> operator*")
-	{
-		auto intPoint = intPoint1 * intPoint2;
-		intPoint *= intPoint * intPoint1;
-		intPoint *= intPoint * intPoint2;
-		intPoint *= intPoint * intPoint1;
-		intPoint *= intPoint * intPoint2;
-		intPoint *= intPoint * intPoint1;
-		intPoint *= intPoint * intPoint2;
-		intPoint *= intPoint * intPoint1;
-		intPoint *= intPoint * intPoint2;
-		sIntPoint *= intPoint;
-	};
-
-	intPoint1 = {1, static_cast<int>(gauranteedNotConstexpr/gauranteedNotConstexpr)};
-	intPoint2 = {1, -1};
-	BENCHMARK("saber::geometry::Point<int> operator/")
-	{
-		auto intPoint = intPoint1 / intPoint2;
-		intPoint /= intPoint / intPoint1;
-		intPoint /= intPoint / intPoint2;
-		intPoint /= intPoint / intPoint1;
-		intPoint /= intPoint / intPoint2;
-		intPoint /= intPoint / intPoint1;
-		intPoint /= intPoint / intPoint2;
-		intPoint /= intPoint / intPoint1;
-		intPoint /= intPoint / intPoint2;
-		sIntPoint /= intPoint;
-	};
+	if constexpr (std::is_same_v<T, int>) return "int";
+	else if constexpr (std::is_same_v<T, float>) return "float";
+	else if constexpr (std::is_same_v<T, double>) return "double";
+	else return "unknown";
 }
 
-saber::geometry::Size<float> sFloatSize{};
-saber::geometry::Size<double> sDoubleSize{};
-saber::geometry::Size<int> sIntSize{};
-
-
-TEST_CASE("saber::geometry::Size", "[saber]")
+template<saber::geometry::ImplKind Impl>
+constexpr const char* ImplName()
 {
-	int gauranteedNotConstexpr = 0;
-	{
-		// TRICKY j3fitz 30nov2024: Prevent compiler from optimizing away all benchmark work.
-		// By using a value in the benchmark computation that can't be known at
-		// compile-time, we force the compiler to emit code to perform computation at
-		// runtime. Otherwise, the compiler is smart enuf to do the math at compile-time
-		// and just emit a final answer at runtime... defeating the purpose of the benchmark!
-
-		// Get current time: "unknowable at compile-time"
-		std::time_t t = std::time(nullptr);
-		std::tm* now = std::localtime(&t);
-		const auto dayOfWeek = now->tm_wday;
-		gauranteedNotConstexpr = dayOfWeek + 1; // +1: -> [1...7]
-	}
-
-	saber::geometry::Size<float> floatSize1{static_cast<float>(gauranteedNotConstexpr), -static_cast<float>(gauranteedNotConstexpr)};
-	saber::geometry::Size<float> floatSize2{2.0f, -3.0f};
-
-	BENCHMARK("saber::geometry::Size<float> operator+")
-	{
-		auto floatSize = floatSize1 + floatSize2;
-		floatSize += floatSize + floatSize1;
-		floatSize += floatSize + floatSize2;
-		floatSize += floatSize + floatSize1;
-		floatSize += floatSize + floatSize2;
-		floatSize += floatSize + floatSize1;
-		floatSize += floatSize + floatSize2;
-		floatSize += floatSize + floatSize1;
-		floatSize += floatSize + floatSize2;
-		sFloatSize += floatSize;
-	};
-
-	BENCHMARK("saber::geometry::Size<float> operator-")
-	{
-		auto floatSize = floatSize1 - floatSize2;
-		floatSize -= floatSize - floatSize1;
-		floatSize -= floatSize - floatSize2;
-		floatSize -= floatSize - floatSize1;
-		floatSize -= floatSize - floatSize2;
-		floatSize -= floatSize - floatSize1;
-		floatSize -= floatSize - floatSize2;
-		floatSize -= floatSize - floatSize1;
-		floatSize -= floatSize - floatSize2;
-		sFloatSize -= floatSize;
-	};
-
-	BENCHMARK("saber::geometry::Size<float> operator*")
-	{
-		auto floatSize = floatSize1 * floatSize2;
-		floatSize *= floatSize * floatSize1;
-		floatSize *= floatSize * floatSize2;
-		floatSize *= floatSize * floatSize1;
-		floatSize *= floatSize * floatSize2;
-		floatSize *= floatSize * floatSize1;
-		floatSize *= floatSize * floatSize2;
-		floatSize *= floatSize * floatSize1;
-		floatSize *= floatSize * floatSize2;
-		sFloatSize *= floatSize;
-	};
-
-	floatSize1 = {1.0f, static_cast<float>(gauranteedNotConstexpr / gauranteedNotConstexpr)};
-	floatSize2 = {1.0f, -1.0f};
-	BENCHMARK("saber::geometry::Size<float> operator/")
-	{
-		auto floatSize = floatSize1 / floatSize2;
-		floatSize /= floatSize / floatSize1;
-		floatSize /= floatSize / floatSize2;
-		floatSize /= floatSize / floatSize1;
-		floatSize /= floatSize / floatSize2;
-		floatSize /= floatSize / floatSize1;
-		floatSize /= floatSize / floatSize2;
-		floatSize /= floatSize / floatSize1;
-		floatSize /= floatSize / floatSize2;
-		sFloatSize /= floatSize;
-	};
-
-	saber::geometry::Size<double> doubleSize1{static_cast<double>(gauranteedNotConstexpr), -static_cast<double>(gauranteedNotConstexpr)};
-	saber::geometry::Size<double> doubleSize2{2.0, -3.0};
-
-	saber::geometry::Size<double> doubleSize3{};
-	BENCHMARK("saber::geometry::Size<double> operator+")
-	{
-		auto doubleSize = doubleSize1 + doubleSize2;
-		doubleSize += doubleSize + doubleSize1;
-		doubleSize += doubleSize + doubleSize2;
-		doubleSize += doubleSize + doubleSize1;
-		doubleSize += doubleSize + doubleSize2;
-		doubleSize += doubleSize + doubleSize1;
-		doubleSize += doubleSize + doubleSize2;
-		doubleSize += doubleSize + doubleSize1;
-		doubleSize += doubleSize + doubleSize2;
-		sDoubleSize += doubleSize;
-	};
-
-	BENCHMARK("saber::geometry::Size<double> operator-")
-	{
-		auto doubleSize = doubleSize1 - doubleSize2;
-		doubleSize -= doubleSize - doubleSize1;
-		doubleSize -= doubleSize - doubleSize2;
-		doubleSize -= doubleSize - doubleSize1;
-		doubleSize -= doubleSize - doubleSize2;
-		doubleSize -= doubleSize - doubleSize1;
-		doubleSize -= doubleSize - doubleSize2;
-		doubleSize -= doubleSize - doubleSize1;
-		doubleSize -= doubleSize - doubleSize2;
-		sDoubleSize -= doubleSize;
-	};
-
-	BENCHMARK("saber::geometry::Size<double> operator*")
-	{
-		auto doubleSize = doubleSize1 * doubleSize2;
-		doubleSize *= doubleSize * doubleSize1;
-		doubleSize *= doubleSize * doubleSize2;
-		doubleSize *= doubleSize * doubleSize1;
-		doubleSize *= doubleSize * doubleSize2;
-		doubleSize *= doubleSize * doubleSize1;
-		doubleSize *= doubleSize * doubleSize2;
-		doubleSize *= doubleSize * doubleSize1;
-		doubleSize *= doubleSize * doubleSize2;
-		sDoubleSize *= doubleSize;
-	};
-
-	doubleSize1 = {1.0, static_cast<double>(gauranteedNotConstexpr / gauranteedNotConstexpr)};
-	doubleSize2 = {1.0, -1.0};
-	BENCHMARK("saber::geometry::Size<double> operator/")
-	{
-		auto doubleSize = doubleSize1 / doubleSize2;
-		doubleSize /= doubleSize / doubleSize1;
-		doubleSize /= doubleSize / doubleSize2;
-		doubleSize /= doubleSize / doubleSize1;
-		doubleSize /= doubleSize / doubleSize2;
-		doubleSize /= doubleSize / doubleSize1;
-		doubleSize /= doubleSize / doubleSize2;
-		doubleSize /= doubleSize / doubleSize1;
-		doubleSize /= doubleSize / doubleSize2;
-		sDoubleSize /= doubleSize;
-	};
-
-	saber::geometry::Size<int> intSize1{static_cast<int>(gauranteedNotConstexpr), -static_cast<int>(gauranteedNotConstexpr)};
-	saber::geometry::Size<int> intSize2{2, -3};
-
-	saber::geometry::Size<int> intSize3{};
-	BENCHMARK("saber::geometry::Size<int> operator+")
-	{
-		auto intSize = intSize1 + intSize2;
-		intSize += intSize + intSize1;
-		intSize += intSize + intSize2;
-		intSize += intSize + intSize1;
-		intSize += intSize + intSize2;
-		intSize += intSize + intSize1;
-		intSize += intSize + intSize2;
-		intSize += intSize + intSize1;
-		intSize += intSize + intSize2;
-		sIntSize += intSize;
-	};
-
-	BENCHMARK("saber::geometry::Size<int> operator-")
-	{
-		auto intSize = intSize1 - intSize2;
-		intSize -= intSize - intSize1;
-		intSize -= intSize - intSize2;
-		intSize -= intSize - intSize1;
-		intSize -= intSize - intSize2;
-		intSize -= intSize - intSize1;
-		intSize -= intSize - intSize2;
-		intSize -= intSize - intSize1;
-		intSize -= intSize - intSize2;
-		sIntSize -= intSize;
-	};
-
-	BENCHMARK("saber::geometry::Size<int> operator*")
-	{
-		auto intSize = intSize1 * intSize2;
-		intSize *= intSize * intSize1;
-		intSize *= intSize * intSize2;
-		intSize *= intSize * intSize1;
-		intSize *= intSize * intSize2;
-		intSize *= intSize * intSize1;
-		intSize *= intSize * intSize2;
-		intSize *= intSize * intSize1;
-		intSize *= intSize * intSize2;
-		sIntSize *= intSize;
-	};
-
-	intSize1 = {1, static_cast<int>(gauranteedNotConstexpr / gauranteedNotConstexpr)};
-	intSize2 = {1, -1};
-	BENCHMARK("saber::geometry::Size<int> operator/")
-	{
-		auto intSize = intSize1 / intSize2;
-		intSize /= intSize / intSize1;
-		intSize /= intSize / intSize2;
-		intSize /= intSize / intSize1;
-		intSize /= intSize / intSize2;
-		intSize /= intSize / intSize1;
-		intSize /= intSize / intSize2;
-		intSize /= intSize / intSize1;
-		intSize /= intSize / intSize2;
-		sIntSize /= intSize;
-	};
+	if constexpr (Impl == saber::geometry::ImplKind::kScalar) return "kScalar";
+	else if constexpr (Impl == saber::geometry::ImplKind::kSimd) return "kSimd";
+	else return "unknown";
 }
+
+template<typename T, saber::geometry::ImplKind Impl>
+std::string WorkloadName(const char* inWorkload)
+{
+	return std::string(inWorkload) + "<" + TypeName<T>() + ", " + ImplName<Impl>() + "> ";
+}
+
+int GauranteedNotConstexpr()
+{
+	// TRICKY j3fitz 30nov2024: Prevent compiler from optimizing away all benchmark work.
+	// By using a value in the benchmark computation that can't be known at
+	// compile-time, we force the compiler to emit code to perform computation at
+	// runtime. Otherwise, the compiler is smart enuf to do the math at compile-time
+	// and just emit a final answer at runtime... defeating the purpose of the benchmark!
+
+	// Get current time: "unknowable at compile-time"
+	std::time_t t = std::time(nullptr);
+	std::tm* now = std::localtime(&t);
+	const auto dayOfWeek = now->tm_wday;
+	auto gauranteedNotConstexpr = dayOfWeek + 1; // +1: -> [1...7]
+	return gauranteedNotConstexpr;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+saber::geometry::Point<T, Impl> sPoint{};
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointAddWork()
+{
+	const auto point1 = sPoint<T, Impl>;
+	const auto point2 = saber::geometry::Point<T, Impl>{ 2, -3 };
+	auto point = point1 + point2;
+
+	point += point + point1;
+	point += point + point2;
+	point += point + point1;
+	point += point + point2;
+	point += point + point1;
+	point += point + point2;
+	point += point + point1;
+	point += point + point2;
+	sPoint<T, Impl> += point;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointSubWork()
+{
+	const auto point1 = sPoint<T, Impl>;
+	const auto point2 = saber::geometry::Point<T, Impl>{ 2, -3 };
+	auto point = point1 - point2;
+
+	point -= point - point1;
+	point -= point - point2;
+	point -= point - point1;
+	point -= point - point2;
+	point -= point - point1;
+	point -= point - point2;
+	point -= point - point1;
+	point -= point - point2;
+	sPoint<T, Impl> -= point;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointMulWork()
+{
+	const auto point1 = sPoint<T, Impl>;
+	const auto point2 = saber::geometry::Point<T, Impl>{ 2, -3 };
+	auto point = point1 * point2;
+
+	point *= point * point1;
+	point *= point * point2;
+	point *= point * point1;
+	point *= point * point2;
+	point *= point * point1;
+	point *= point * point2;
+	point *= point * point1;
+	point *= point * point2;
+	sPoint<T, Impl> *= point;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointDivWork()
+{
+	const auto point1 = sPoint<T, Impl>;
+	const auto point2 = saber::geometry::Point<T, Impl>{ -1, -1 };
+	auto point = point1 / point2;
+
+	point /= point / point1;
+	point /= point / point2;
+	point /= point / point1;
+	point /= point / point2;
+	point /= point / point1;
+	point /= point / point2;
+	point /= point / point1;
+	point /= point / point2;
+	sPoint<T, Impl> /= point;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointScaleWork()
+{
+	const auto point1 = sPoint<T, Impl>;
+	const auto point2 = saber::geometry::Point<T, Impl>{ -2, 3 };
+	auto point = saber::geometry::Scale(point1, point2);
+
+	point.Scale(saber::geometry::Scale(point, point1));
+	point.Scale(saber::geometry::Scale(point, point2));
+	point.Scale(saber::geometry::Scale(point, point1));
+	point.Scale(saber::geometry::Scale(point, point2));
+	point.Scale(saber::geometry::Scale(point, point1));
+	point.Scale(saber::geometry::Scale(point, point2));
+	point.Scale(saber::geometry::Scale(point, point1));
+	point.Scale(saber::geometry::Scale(point, point2));
+	sPoint<T, Impl>.Scale(point);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointTranslateWork()
+{
+	const auto point1 = sPoint<T, Impl>;
+	const auto point2 = saber::geometry::Point<T, Impl>{ -2, 3 };
+	auto point = saber::geometry::Translate(point1, point2);
+
+	point.Translate(saber::geometry::Translate(point, point1));
+	point.Translate(saber::geometry::Translate(point, point2));
+	point.Translate(saber::geometry::Translate(point, point1));
+	point.Translate(saber::geometry::Translate(point, point2));
+	point.Translate(saber::geometry::Translate(point, point1));
+	point.Translate(saber::geometry::Translate(point, point2));
+	point.Translate(saber::geometry::Translate(point, point1));
+	point.Translate(saber::geometry::Translate(point, point2));
+	sPoint<T, Impl>.Translate(point);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointCeilWork()
+{
+	auto point = saber::geometry::RoundCeil(sPoint<T, Impl>);
+
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	point = saber::geometry::RoundCeil(point.RoundCeil());
+	sPoint<T, Impl> = saber::geometry::RoundCeil(point);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointFloorWork()
+{
+	auto point = saber::geometry::RoundFloor(sPoint<T, Impl>);
+
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	point = saber::geometry::RoundFloor(point.RoundFloor());
+	sPoint<T, Impl> = saber::geometry::RoundFloor(point);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointNearestWork()
+{
+	auto point = saber::geometry::RoundNearest(sPoint<T, Impl>);
+
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	point = saber::geometry::RoundNearest(point.RoundNearest());
+	sPoint<T, Impl> = saber::geometry::RoundNearest(point);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void PointTruncWork()
+{
+	auto point = saber::geometry::RoundTrunc(sPoint<T, Impl>);
+
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	point = saber::geometry::RoundTrunc(point.RoundTrunc());
+	sPoint<T, Impl> = saber::geometry::RoundTrunc(point);
+}
+
+TEMPLATE_TEST_CASE("saber::geometry::Point", "[saber][benchmark][template]", int, float, double)
+{
+	using namespace saber::geometry;
+
+	const auto x = static_cast<TestType>(GauranteedNotConstexpr() + 0);
+	const auto y = static_cast<TestType>(GauranteedNotConstexpr() + 1);
+
+	sPoint<TestType, ImplKind::kScalar> = { x, y };
+	sPoint<TestType, ImplKind::kSimd> = { x, y };
+
+	const auto pointScalarName = WorkloadName<TestType, ImplKind::kScalar>("Point");
+	const auto pointSimdName = WorkloadName<TestType, ImplKind::kSimd>("Point");
+
+	BENCHMARK(pointScalarName + "operator+") { PointAddWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(pointSimdName + "operator+") { PointAddWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(pointScalarName + "operator-") { PointSubWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(pointSimdName + "operator-") { PointSubWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(pointScalarName + "operator*") { PointMulWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(pointSimdName + "operator*") { PointMulWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(pointScalarName + "operator/") { PointDivWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(pointSimdName + "operator/") { PointDivWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(pointScalarName + "Scale()") { PointScaleWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(pointSimdName + "Scale()") { PointScaleWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(pointScalarName + "Translate()") { PointTranslateWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(pointSimdName + "Translate()") { PointTranslateWork<TestType, ImplKind::kSimd>(); };
+
+	if constexpr (std::is_floating_point_v<TestType>)
+	{
+		// Rounding APIs are only available for floating point types
+		BENCHMARK(pointScalarName + "RoundCeil()") { PointCeilWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(pointSimdName + "RoundCeil()") { PointCeilWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(pointScalarName + "RoundFloor()") { PointFloorWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(pointSimdName + "RoundFloor()") { PointFloorWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(pointScalarName + "RoundNearest()") { PointNearestWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(pointSimdName + "RoundNearest()") { PointNearestWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(pointScalarName + "RoundTrunc()") { PointTruncWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(pointSimdName + "RoundTrunc()") { PointTruncWork<TestType, ImplKind::kSimd>(); };
+	}
+};
+
+template<typename T, saber::geometry::ImplKind Impl>
+saber::geometry::Size<T, Impl> sSize{};
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeAddWork()
+{
+	const auto size1 = sSize<T, Impl>;
+	const auto size2 = saber::geometry::Size<T, Impl>{ 2, -3 };
+
+	auto size = size1 + size2;
+	size += size + size1;
+	size += size + size2;
+	size += size + size1;
+	size += size + size2;
+	size += size + size1;
+	size += size + size2;
+	size += size + size1;
+	size += size + size2;
+	sSize<T, Impl> += size;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeSubWork()
+{
+	const auto size1 = sSize<T, Impl>;
+	const auto size2 = saber::geometry::Size<T, Impl>{ 2, -3 };
+
+	auto size = size1 - size2;
+	size -= size - size1;
+	size -= size - size2;
+	size -= size - size1;
+	size -= size - size2;
+	size -= size - size1;
+	size -= size - size2;
+	size -= size - size1;
+	size -= size - size2;
+	sSize<T, Impl> -= size;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeMulWork()
+{
+	const auto size1 = sSize<T, Impl>;
+	const auto size2 = saber::geometry::Size<T, Impl>{ 2, -3 };
+
+	auto size = size1 * size2;
+	size *= size * size1;
+	size *= size * size2;
+	size *= size * size1;
+	size *= size * size2;
+	size *= size * size1;
+	size *= size * size2;
+	size *= size * size1;
+	size *= size * size2;
+	sSize<T, Impl> *= size;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeDivWork()
+{
+	const auto size1 = sSize<T, Impl>;
+	const auto size2 = saber::geometry::Size<T, Impl>{ -1, -1 };
+
+	auto size = size1 / size2;
+	size /= size / size1;
+	size /= size / size2;
+	size /= size / size1;
+	size /= size / size2;
+	size /= size / size1;
+	size /= size / size2;
+	size /= size / size1;
+	size /= size / size2;
+	sSize<T, Impl> /= size;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeScaleWork()
+{
+	const auto size1 = sSize<T, Impl>;
+	const auto size2 = saber::geometry::Size<T, Impl>{ 2, -3 };
+	auto size = Scale(size1, size2);
+
+	size.Scale(saber::geometry::Scale(size, size1));
+	size.Scale(saber::geometry::Scale(size, size2));
+	size.Scale(saber::geometry::Scale(size, size1));
+	size.Scale(saber::geometry::Scale(size, size2));
+	size.Scale(saber::geometry::Scale(size, size1));
+	size.Scale(saber::geometry::Scale(size, size2));
+	size.Scale(saber::geometry::Scale(size, size1));
+	size.Scale(saber::geometry::Scale(size, size2));
+	sSize<T, Impl>.Scale(size);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeEnlargeWork()
+{
+	const auto size1 = sSize<T, Impl>;
+	const auto size2 = saber::geometry::Size<T, Impl>{ 2, -3 };
+	auto size = saber::geometry::Enlarge(size1, size2);
+
+	size.Enlarge(saber::geometry::Enlarge(size, size1));
+	size.Enlarge(saber::geometry::Enlarge(size, size2));
+	size.Enlarge(saber::geometry::Enlarge(size, size1));
+	size.Enlarge(saber::geometry::Enlarge(size, size2));
+	size.Enlarge(saber::geometry::Enlarge(size, size1));
+	size.Enlarge(saber::geometry::Enlarge(size, size2));
+	size.Enlarge(saber::geometry::Enlarge(size, size1));
+	size.Enlarge(saber::geometry::Enlarge(size, size2));
+	sSize<T, Impl>.Enlarge(size);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeCeilWork()
+{
+	auto size = saber::geometry::RoundCeil(sSize<T, Impl>);
+
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	size = saber::geometry::RoundCeil(size.RoundCeil());
+	sSize<T, Impl> = saber::geometry::RoundCeil(size);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeFloorWork()
+{
+	auto size = saber::geometry::RoundFloor(sSize<T, Impl>);
+
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	size = saber::geometry::RoundFloor(size.RoundFloor());
+	sSize<T, Impl> = saber::geometry::RoundFloor(size);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeNearestWork()
+{
+	auto size = saber::geometry::RoundNearest(sSize<T, Impl>);
+
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	size = saber::geometry::RoundNearest(size.RoundNearest());
+	sSize<T, Impl> = saber::geometry::RoundNearest(size);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void SizeTruncWork()
+{
+	auto size = saber::geometry::RoundTrunc(sSize<T, Impl>);
+
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	size = saber::geometry::RoundTrunc(size.RoundTrunc());
+	sSize<T, Impl> = saber::geometry::RoundTrunc(size);
+}
+
+TEMPLATE_TEST_CASE("saber::geometry::Size", "[saber][benchmark][template]", int, float, double)
+{
+	using namespace saber::geometry;
+
+	const auto width = static_cast<TestType>(GauranteedNotConstexpr() + 0);
+	const auto height = static_cast<TestType>(GauranteedNotConstexpr() + 1);
+
+	sSize<TestType, ImplKind::kScalar> = { width, height };
+	sSize<TestType, ImplKind::kSimd> = { width, height };
+
+	const auto sizeScalarName = WorkloadName<TestType, ImplKind::kScalar>("Size");
+	const auto sizeSimdName = WorkloadName<TestType, ImplKind::kSimd>("Size");
+
+	BENCHMARK(sizeScalarName + "operator+") { SizeAddWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(sizeSimdName + "operator+") { SizeAddWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(sizeScalarName + "operator-") { SizeSubWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(sizeSimdName + "operator-") { SizeSubWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(sizeScalarName + "operator*") { SizeMulWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(sizeSimdName + "operator*") { SizeMulWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(sizeScalarName + "operator/") { SizeDivWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(sizeSimdName + "operator/") { SizeDivWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(sizeScalarName + "Scale()") { SizeScaleWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(sizeSimdName + "Scale()") { SizeScaleWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(sizeScalarName + "Enlarge()") { SizeEnlargeWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(sizeSimdName + "Enlarge()") { SizeEnlargeWork<TestType, ImplKind::kSimd>(); };
+
+	if constexpr (std::is_floating_point_v<TestType>)
+	{
+		// Rounding APIs are only available for floating point types
+		BENCHMARK(sizeScalarName + "RoundCeil()") { SizeCeilWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(sizeSimdName + "RoundCeil()") { SizeCeilWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(sizeScalarName + "RoundFloor()") { SizeFloorWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(sizeSimdName + "RoundFloor()") { SizeFloorWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(sizeScalarName + "RoundNearest()") { SizeNearestWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(sizeSimdName + "RoundNearest()") { SizeNearestWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(sizeScalarName + "RoundTrunc()") { SizeTruncWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(sizeSimdName + "RoundTrunc()") { SizeTruncWork<TestType, ImplKind::kSimd>(); };
+	}
+};
+
+template<typename T, saber::geometry::ImplKind Impl>
+saber::geometry::Rectangle<T, Impl> sRectangle{};
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleTranslateWork()
+{
+	const auto rect1 = sRectangle<T, Impl>;
+	const auto point = saber::geometry::Point<T, Impl>{ 2, -3 };
+	auto rect = Translate(rect1, point);
+
+	rect.Translate(Translate(rect, point).Origin());
+	rect.Translate(Translate(rect, point).Origin());
+	rect.Translate(Translate(rect, point).Origin());
+	rect.Translate(Translate(rect, point).Origin());
+	rect.Translate(Translate(rect, point).Origin());
+	rect.Translate(Translate(rect, point).Origin());
+	rect.Translate(Translate(rect, point).Origin());
+	rect.Translate(Translate(rect, point).Origin());
+	sRectangle<T, Impl>.Translate(rect.Origin());
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleEnlargeWork()
+{
+	const auto rect1 = sRectangle<T, Impl>;
+	const auto size = saber::geometry::Size<T, Impl>{ 2, -3 };
+	auto rect = Enlarge(rect1, size);
+
+	rect.Enlarge(Enlarge(rect, size).Size());
+	rect.Enlarge(Enlarge(rect, size).Size());
+	rect.Enlarge(Enlarge(rect, size).Size());
+	rect.Enlarge(Enlarge(rect, size).Size());
+	rect.Enlarge(Enlarge(rect, size).Size());
+	rect.Enlarge(Enlarge(rect, size).Size());
+	rect.Enlarge(Enlarge(rect, size).Size());
+	rect.Enlarge(Enlarge(rect, size).Size());
+	sRectangle<T, Impl>.Enlarge(rect.Size());
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleScaleWork()
+{
+	const auto rect1 = sRectangle<T, Impl>;
+	const auto size = saber::geometry::Size<T, Impl>{ 2, -3 };
+	auto rect = Scale(rect1, size);
+
+	rect.Scale(Scale(rect, size).Origin());
+	rect.Scale(Scale(rect, size).Size());
+	rect.Scale(Scale(rect, size).Origin());
+	rect.Scale(Scale(rect, size).Size());
+	rect.Scale(Scale(rect, size).Origin());
+	rect.Scale(Scale(rect, size).Size());
+	rect.Scale(Scale(rect, size).Origin());
+	rect.Scale(Scale(rect, size).Size());
+	sRectangle<T, Impl>.Scale(rect.Origin());
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleUnionWork()
+{
+	const auto rect1 = sRectangle<T, Impl>;
+	const auto rect2 = saber::geometry::Rectangle<T, Impl>{ 2, -3, 10, 5 };
+	auto rect = Union(rect1, rect2);
+
+	rect.Union(Union(rect, rect2));
+	rect.Union(Union(rect, rect1));
+	rect.Union(Union(rect, rect2));
+	rect.Union(Union(rect, rect1));
+	rect.Union(Union(rect, rect2));
+	rect.Union(Union(rect, rect1));
+	rect.Union(Union(rect, rect2));
+	rect.Union(Union(rect, rect1));
+	sRectangle<T, Impl>.Union(rect);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleIntersectWork()
+{
+	const auto rect1 = sRectangle<T, Impl>;
+	const auto rect2 = saber::geometry::Rectangle<T, Impl>{ 2, -3, 10, 5 };
+	auto rect = Intersect(rect1, rect2);
+
+	rect.Intersect(Intersect(rect, rect2));
+	rect.Intersect(Intersect(rect, rect1));
+	rect.Intersect(Intersect(rect, rect2));
+	rect.Intersect(Intersect(rect, rect1));
+	rect.Intersect(Intersect(rect, rect2));
+	rect.Intersect(Intersect(rect, rect1));
+	rect.Intersect(Intersect(rect, rect2));
+	rect.Intersect(Intersect(rect, rect1));
+	sRectangle<T, Impl>.Intersect(rect);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleIsOverlappingPointWork()
+{
+	const auto rect = sRectangle<T, Impl>;
+	const auto point1 = saber::geometry::Point<T, Impl>{ 1, 1 };
+	const auto point2 = saber::geometry::Point<T, Impl>{ 2, -3 };
+
+	volatile bool result = false;
+	result = IsOverlapping(rect, point1);
+	result = rect.IsOverlapping(point2);
+	result = IsOverlapping(rect, point2);
+	result = rect.IsOverlapping(point1);
+	result = IsOverlapping(rect, point1);
+	result = rect.IsOverlapping(point2);
+	result = IsOverlapping(rect, point2);
+	result = rect.IsOverlapping(point1);
+	result = IsOverlapping(rect, point1);
+	(void)result;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleIsOverlappingRectWork()
+{
+	const auto rect1 = sRectangle<T, Impl>;
+	const auto rect2 = saber::geometry::Rectangle<T, Impl>{ 2, -3, 10, 5 };
+
+	volatile bool result = false;
+	result = IsOverlapping(rect1, rect2);
+	result = rect1.IsOverlapping(rect2);
+	result = IsOverlapping(rect2, rect1);
+	result = rect2.IsOverlapping(rect1);
+	result = IsOverlapping(rect1, rect2);
+	result = rect1.IsOverlapping(rect2);
+	result = IsOverlapping(rect2, rect1);
+	result = rect2.IsOverlapping(rect1);
+	result = IsOverlapping(rect1, rect2);
+	(void)result;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleIsEmptyWork()
+{
+	const auto rect1 = sRectangle<T, Impl>;
+	const auto rect2 = saber::geometry::Rectangle<T, Impl>{ 2, -3, 10, 5 };
+
+	volatile bool result = false;
+	result = IsEmpty(rect1);
+	result = IsEmpty(rect2);
+	result = IsEmpty(rect1);
+	result = IsEmpty(rect2);
+	result = IsEmpty(rect1);
+	result = IsEmpty(rect2);
+	result = IsEmpty(rect1);
+	result = IsEmpty(rect2);
+	result = IsEmpty(rect1);
+	(void)result;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleCeilWork()
+{
+	auto rect = RoundCeil(sRectangle<T, Impl>);
+
+	rect = RoundCeil(rect.RoundCeil());
+	rect = RoundCeil(rect.RoundCeil());
+	rect = RoundCeil(rect.RoundCeil());
+	rect = RoundCeil(rect.RoundCeil());
+	rect = RoundCeil(rect.RoundCeil());
+	rect = RoundCeil(rect.RoundCeil());
+	rect = RoundCeil(rect.RoundCeil());
+	rect = RoundCeil(rect.RoundCeil());
+	sRectangle<T, Impl> = RoundCeil(rect);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleFloorWork()
+{
+	auto rect = RoundFloor(sRectangle<T, Impl>);
+
+	rect = RoundFloor(rect.RoundFloor());
+	rect = RoundFloor(rect.RoundFloor());
+	rect = RoundFloor(rect.RoundFloor());
+	rect = RoundFloor(rect.RoundFloor());
+	rect = RoundFloor(rect.RoundFloor());
+	rect = RoundFloor(rect.RoundFloor());
+	rect = RoundFloor(rect.RoundFloor());
+	rect = RoundFloor(rect.RoundFloor());
+	sRectangle<T, Impl> = RoundFloor(rect);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleNearestWork()
+{
+	auto rect = RoundNearest(sRectangle<T, Impl>);
+
+	rect = RoundNearest(rect.RoundNearest());
+	rect = RoundNearest(rect.RoundNearest());
+	rect = RoundNearest(rect.RoundNearest());
+	rect = RoundNearest(rect.RoundNearest());
+	rect = RoundNearest(rect.RoundNearest());
+	rect = RoundNearest(rect.RoundNearest());
+	rect = RoundNearest(rect.RoundNearest());
+	rect = RoundNearest(rect.RoundNearest());
+	sRectangle<T, Impl> = RoundNearest(rect);
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void RectangleTruncWork()
+{
+	auto rect = RoundTrunc(sRectangle<T, Impl>);
+
+	rect = RoundTrunc(rect.RoundTrunc());
+	rect = RoundTrunc(rect.RoundTrunc());
+	rect = RoundTrunc(rect.RoundTrunc());
+	rect = RoundTrunc(rect.RoundTrunc());
+	rect = RoundTrunc(rect.RoundTrunc());
+	rect = RoundTrunc(rect.RoundTrunc());
+	rect = RoundTrunc(rect.RoundTrunc());
+	rect = RoundTrunc(rect.RoundTrunc());
+	sRectangle<T, Impl> = RoundTrunc(rect);
+}
+
+TEMPLATE_TEST_CASE("saber::geometry::Rectangle", "[saber][benchmark][template]", int, float, double)
+{
+	using namespace saber::geometry;
+
+	sRectangle<TestType, ImplKind::kScalar>.X(static_cast<TestType>(GauranteedNotConstexpr() + 0));
+	sRectangle<TestType, ImplKind::kScalar>.Y(static_cast<TestType>(GauranteedNotConstexpr() + 1));
+	sRectangle<TestType, ImplKind::kScalar>.Width(static_cast<TestType>(GauranteedNotConstexpr() + 2));
+	sRectangle<TestType, ImplKind::kScalar>.Height(static_cast<TestType>(GauranteedNotConstexpr() + 3));
+
+	sRectangle<TestType, ImplKind::kSimd>.X(static_cast<TestType>(GauranteedNotConstexpr() + 0));
+	sRectangle<TestType, ImplKind::kSimd>.Y(static_cast<TestType>(GauranteedNotConstexpr() + 1));
+	sRectangle<TestType, ImplKind::kSimd>.Width(static_cast<TestType>(GauranteedNotConstexpr() + 2));
+	sRectangle<TestType, ImplKind::kSimd>.Height(static_cast<TestType>(GauranteedNotConstexpr() + 3));
+
+	const auto rectScalarName = WorkloadName<TestType, ImplKind::kScalar>("Rectangle");
+	const auto rectSimdName = WorkloadName<TestType, ImplKind::kSimd>("Rectangle");
+
+	BENCHMARK(rectScalarName + "Translate()") { RectangleTranslateWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "Translate()") { RectangleTranslateWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(rectScalarName + "Enlarge()") { RectangleEnlargeWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "Enlarge()") { RectangleEnlargeWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(rectScalarName + "Scale()") { RectangleScaleWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "Scale()") { RectangleScaleWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(rectScalarName + "Union()") { RectangleUnionWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "Union()") { RectangleUnionWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(rectScalarName + "Intersect()") { RectangleIntersectWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "Intersect()") { RectangleIntersectWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(rectScalarName + "IsOverlapping(Point)") { RectangleIsOverlappingPointWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "IsOverlapping(Point)") { RectangleIsOverlappingPointWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(rectScalarName + "IsOverlapping(Rectangle)") { RectangleIsOverlappingRectWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "IsOverlapping(Rectangle)") { RectangleIsOverlappingRectWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(rectScalarName + "IsEmpty()") { RectangleIsEmptyWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(rectSimdName + "IsEmpty()") { RectangleIsEmptyWork<TestType, ImplKind::kSimd>(); };
+
+	if constexpr (std::is_floating_point_v<TestType>)
+	{
+		// Rounding APIs are only available for floating point types
+		BENCHMARK(rectScalarName + "RoundCeil()") { RectangleCeilWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(rectSimdName + "RoundCeil()") { RectangleCeilWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(rectScalarName + "RoundFloor()") { RectangleFloorWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(rectSimdName + "RoundFloor()") { RectangleFloorWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(rectScalarName + "RoundNearest()") { RectangleNearestWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(rectSimdName + "RoundNearest()") { RectangleNearestWork<TestType, ImplKind::kSimd>(); };
+
+		BENCHMARK(rectScalarName + "RoundTrunc()") { RectangleTruncWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(rectSimdName + "RoundTrunc()") { RectangleTruncWork<TestType, ImplKind::kSimd>(); };
+	}
+};
+
+template<typename T, saber::geometry::ImplKind Impl>
+saber::geometry::Matrix<T, Impl> sMatrix{};
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixMakeIdentityWork()
+{
+	auto mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+	sMatrix<T, Impl> = mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixMakeZeroWork()
+{
+	auto mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	mat = saber::geometry::Matrix<T, Impl>::MakeZero();
+	sMatrix<T, Impl> = mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixMakeScaleWork()
+{
+	const auto point1 = saber::geometry::Point<T, Impl>{ 2, -3 };
+	const auto point2 = saber::geometry::Point<T, Impl>{ -1, 4 };
+	auto mat = saber::geometry::Matrix<T, Impl>::MakeScale(point1);
+
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeScale(point1);
+	sMatrix<T, Impl> = mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixMakeTranslationWork()
+{
+	const auto point1 = saber::geometry::Point<T, Impl>{ 2, -3 };
+	const auto point2 = saber::geometry::Point<T, Impl>{ -1, 4 };
+	auto mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point1);
+
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeTranslation(point1);
+	sMatrix<T, Impl> = mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixAddWork()
+{
+	const auto mat1 = sMatrix<T, Impl>;
+	const auto mat2 = saber::geometry::Matrix<T, Impl>{ 2, -3, 1, 0, 2, -1 };
+	auto mat = mat1;
+
+	mat += mat2;
+	mat += mat + mat2;
+	mat += mat + mat1;
+	mat += mat + mat2;
+	mat += mat + mat1;
+	mat += mat + mat2;
+	mat += mat + mat1;
+	mat += mat + mat2;
+	mat += mat + mat1;
+	sMatrix<T, Impl> += mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixSubWork()
+{
+	const auto mat1 = sMatrix<T, Impl>;
+	const auto mat2 = saber::geometry::Matrix<T, Impl>{ 2, -3, 1, 0, 2, -1 };
+	auto mat = mat1;
+
+	mat -= mat2;
+	mat -= mat - mat2;
+	mat -= mat - mat1;
+	mat -= mat - mat2;
+	mat -= mat - mat1;
+	mat -= mat - mat2;
+	mat -= mat - mat1;
+	mat -= mat - mat2;
+	mat -= mat - mat1;
+	sMatrix<T, Impl> -= mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixMulWork()
+{
+	const auto mat1 = sMatrix<T, Impl>;
+	const auto mat2 = saber::geometry::Matrix<T, Impl>{ 2, -3, 1, 0, 2, -1 };
+	auto mat = mat1;
+
+	mat *= mat2;
+	mat *= mat2;
+	mat *= mat2;
+	mat *= mat2;
+	mat *= mat2;
+	mat *= mat2;
+	mat *= mat2;
+	mat *= mat2;
+	mat *= mat2;
+	sMatrix<T, Impl> *= mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixInvertWork()
+{
+	// TRICKY: Invert() is only numerically valid on non-singular matrices.
+	// Reset to MakeIdentity() each iteration so every Invert() call acts on
+	// a well-conditioned (orthogonal) matrix: inv(I) == I, inv(inv(M)) == M.
+	auto mat = saber::geometry::Matrix<T, Impl>::MakeIdentity();
+
+	mat.Invert();
+	mat.Invert();
+	mat.Invert();
+	mat.Invert();
+	mat.Invert();
+	mat.Invert();
+	mat.Invert();
+	mat.Invert();
+	mat.Invert();
+	sMatrix<T, Impl> = mat;
+}
+
+template<typename T, saber::geometry::ImplKind Impl>
+void MatrixMakeRotationWork()
+{
+	// MakeRotation() is only available for floating point types (calls std::sin/cos).
+	// Varied angles prevent the compiler from folding repeated calls into one.
+	const T angle1 = static_cast<T>(GauranteedNotConstexpr());
+	const T angle2 = static_cast<T>(GauranteedNotConstexpr() + 1);
+	auto mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle1);
+
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle1);
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle2);
+	mat = saber::geometry::Matrix<T, Impl>::MakeRotation(angle1);
+	sMatrix<T, Impl> = mat;
+}
+
+TEMPLATE_TEST_CASE("saber::geometry::Matrix", "[saber][benchmark][template]", int, float, double)
+{
+	using namespace saber::geometry;
+
+	sMatrix<TestType, ImplKind::kScalar>.M11(static_cast<TestType>(GauranteedNotConstexpr() + 0));
+	sMatrix<TestType, ImplKind::kScalar>.M12(static_cast<TestType>(GauranteedNotConstexpr() + 1));
+	sMatrix<TestType, ImplKind::kScalar>.M13(static_cast<TestType>(GauranteedNotConstexpr() + 2));
+	sMatrix<TestType, ImplKind::kScalar>.M21(static_cast<TestType>(GauranteedNotConstexpr() + 3));
+	sMatrix<TestType, ImplKind::kScalar>.M22(static_cast<TestType>(GauranteedNotConstexpr() + 4));
+	sMatrix<TestType, ImplKind::kScalar>.M23(static_cast<TestType>(GauranteedNotConstexpr() + 5));
+
+	sMatrix<TestType, ImplKind::kSimd>.M11(static_cast<TestType>(GauranteedNotConstexpr() + 0));
+	sMatrix<TestType, ImplKind::kSimd>.M12(static_cast<TestType>(GauranteedNotConstexpr() + 1));
+	sMatrix<TestType, ImplKind::kSimd>.M13(static_cast<TestType>(GauranteedNotConstexpr() + 2));
+	sMatrix<TestType, ImplKind::kSimd>.M21(static_cast<TestType>(GauranteedNotConstexpr() + 3));
+	sMatrix<TestType, ImplKind::kSimd>.M22(static_cast<TestType>(GauranteedNotConstexpr() + 4));
+	sMatrix<TestType, ImplKind::kSimd>.M23(static_cast<TestType>(GauranteedNotConstexpr() + 5));
+
+	const auto matrixNameScalar = WorkloadName<TestType, ImplKind::kScalar>("Matrix");
+	const auto matrixNameSimd = WorkloadName<TestType, ImplKind::kSimd>("Matrix");
+
+	BENCHMARK(matrixNameScalar + "MakeIdentity()") { MatrixMakeIdentityWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "MakeIdentity()") { MatrixMakeIdentityWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(matrixNameScalar + "MakeZero()") { MatrixMakeZeroWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "MakeZero()") { MatrixMakeZeroWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(matrixNameScalar + "MakeScale()") { MatrixMakeScaleWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "MakeScale()") { MatrixMakeScaleWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(matrixNameScalar + "MakeTranslation()") { MatrixMakeTranslationWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "MakeTranslation()") { MatrixMakeTranslationWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(matrixNameScalar + "operator+=") { MatrixAddWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "operator+=") { MatrixAddWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(matrixNameScalar + "operator-=") { MatrixSubWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "operator-=") { MatrixSubWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(matrixNameScalar + "operator*=") { MatrixMulWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "operator*=") { MatrixMulWork<TestType, ImplKind::kSimd>(); };
+
+	BENCHMARK(matrixNameScalar + "Invert()") { MatrixInvertWork<TestType, ImplKind::kScalar>(); };
+	BENCHMARK(matrixNameSimd + "Invert()") { MatrixInvertWork<TestType, ImplKind::kSimd>(); };
+
+	if constexpr (std::is_floating_point_v<TestType>)
+	{
+		// MakeRotation() calls std::sin/cos and is only meaningful for floating point types
+		BENCHMARK(matrixNameScalar + "MakeRotation()") { MatrixMakeRotationWork<TestType, ImplKind::kScalar>(); };
+		BENCHMARK(matrixNameSimd + "MakeRotation()") { MatrixMakeRotationWork<TestType, ImplKind::kSimd>(); };
+	}
+};

--- a/test/saber_unittest.cpp
+++ b/test/saber_unittest.cpp
@@ -82,10 +82,8 @@ TEST_CASE(	"saber::Exception and macros (REQUIRE, ENSURE, ASSERT)",
 
 	SECTION("SABER_ASSERT with true condition does not throw")
 	{
-		bool cond = true;
-		bool cond2 = (1 == 1);
-		REQUIRE_NOTHROW(SABER_ASSERT(cond));
-		REQUIRE_NOTHROW(SABER_ASSERT(cond2));
+		REQUIRE_NOTHROW(SABER_ASSERT(true));
+		REQUIRE_NOTHROW(SABER_ASSERT(1 == 1));
 	}
 
 	SECTION("saber::Exception derives from std::runtime_error")


### PR DESCRIPTION
Use Claude Code to update `geometry_benchmark` to measure performance of both` kScalar` and `kSimd` variants of `saber::geometry` classes. Added benchmarks for new types `Rectangle` and `Matrix`. Also made fixes for latent compile errors.